### PR TITLE
fix makefile typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ support.check:
 		echo "Checking $${name}";\
 		cd $${name} && make check && cd ../../ || exit 1;\
 	done
-.PHONE: support.check
+.PHONY: support.check
 
 sdk.check:
 	for name in packages/{$(SDK_PKGS)}; do\
@@ -167,7 +167,7 @@ support.format:
 		echo "Formatting $${name}";\
 		cd $${name} && make format && cd ../../ || exit 1;\
 	done
-.PHONE: support.format
+.PHONY: support.format
 
 sdk.format:
 	for name in packages/{$(SDK_PKGS)}; do\


### PR DESCRIPTION
### TL;DR

Fixed typos in Makefile phony targets.

### What changed?

Corrected the spelling of `.PHONY` for two targets in the Makefile:
- Changed `.PHONE: support.check` to `.PHONY: support.check`
- Changed `.PHONE: support.format` to `.PHONY: support.format`

### How to test?

1. Open the Makefile
2. Verify that the `.PHONY` declarations for `support.check` and `support.format` are correctly spelled
3. Run `make support.check` and `make support.format` to ensure they still function as expected

### Why make this change?

This change ensures that the `support.check` and `support.format` targets are correctly declared as phony targets. Proper `.PHONY` declarations prevent potential conflicts with files of the same name and improve Makefile performance by avoiding unnecessary checks for these targets.

---

