### PR TITLE
add ens name resolution

### DIFF
--- a/packages/iframe/src/listeners/index.ts
+++ b/packages/iframe/src/listeners/index.ts
@@ -1,9 +1,10 @@
 import { AuthState } from "@happychain/sdk-shared"
 import { getDefaultStore } from "jotai/vanilla"
+import { http, createPublicClient } from "viem"
+import { mainnet } from "viem/chains"
 import { dappMessageBus } from "../services/eventBus"
 import { hasPermission } from "../services/permissions/hasPermission"
 import { authStateAtom } from "../state/authState"
-// import { publicClientAtom } from "../state/publicClient"
 import { userAtom } from "../state/user"
 import { emitUserUpdate } from "../utils/emitUserUpdate"
 
@@ -76,17 +77,16 @@ store.sub(userAtom, () => {
  *
  * @listens userAtom
  */
-// store.sub(userAtom, async () => {
-//     const user = store.get(userAtom)
-//     // don't update if ens already has been found
-//     if (!user || user.ens) return
+const mainnetClient = createPublicClient({ chain: mainnet, transport: http() })
+store.sub(userAtom, async () => {
+    const user = store.get(userAtom)
+    // don't update if ens already has been found
+    if (!user || user.ens) return
 
-//     const ensName = await store.get(publicClientAtom).getEnsName({
-//         address: user.address,
-//     })
+    const ensName = await mainnetClient.getEnsName({ address: user.address })
 
-//     if (ensName) {
-//         user.ens = ensName
-//         store.set(userAtom, user)
-//     }
-// })
+    if (ensName) {
+        user.ens = ensName
+        store.set(userAtom, user)
+    }
+})

--- a/packages/iframe/src/routes/connect.lazy.tsx
+++ b/packages/iframe/src/routes/connect.lazy.tsx
@@ -90,7 +90,7 @@ function Connect() {
                             onClick={open}
                         >
                             <img src={user.avatar} alt={`${user.name}'s avatar`} className="h-8 rounded-full" />
-                            <p>{user?.email || user?.name}</p>
+                            <p>{user?.ens || user?.email || user?.name}</p>
                         </div>
                     )}
                 </div>


### PR DESCRIPTION
### TL;DR

Implemented ENS name resolution for connected users and updated the UI to display ENS names.

### What changed?

- Added ENS name resolution functionality using Viem's `createPublicClient` and the Ethereum mainnet.
- Uncommented and updated the user subscription logic to fetch and store ENS names.
- Modified the Connect component to display the user's ENS name if available.

### How to test?

1. Connect a wallet with an associated ENS name.
2. Verify that the ENS name is fetched and displayed in the UI.
3. Test with wallets that have and don't have ENS names to ensure proper fallback to email or name.

### Why make this change?

This change enhances user experience by displaying ENS names, which are often more recognizable and user-friendly than Ethereum addresses. It provides a more personalized interface for users who have registered ENS names, while maintaining compatibility with users who don't have ENS names associated with their addresses.

---

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/c844d688-e91a-4912-8918-a5b37cdbea1e.png)

