### PR TITLE
closes: HAPPY-50 console warnings if functions are called before initialize

### DIFF
--- a/packages/iframe/src/providers/HappyAccountProvider.tsx
+++ b/packages/iframe/src/providers/HappyAccountProvider.tsx
@@ -5,6 +5,7 @@ import { type PropsWithChildren, useEffect, useState } from "react"
 import { useProcessConfirmedRequests } from "../hooks/useProcessConfirmedRequests"
 import { useProcessUnconfirmedRequests } from "../hooks/useProcessUnconfirmedRequests"
 import { useProviderEventsProxy } from "../hooks/useProviderEventsProxy"
+import { dappMessageBus } from "../services/eventBus"
 
 function useInitializeWeb3() {
     const [isWeb3Initialized, setIsWeb3Initialized] = useState(false)
@@ -48,6 +49,12 @@ export function HappyAccountProvider({ children }: PropsWithChildren) {
      * to bypass the user confirmation screen
      */
     useProcessUnconfirmedRequests()
+
+    useEffect(() => {
+        if (isWeb3Initialized) {
+            dappMessageBus.emit("iframe-init", true)
+        }
+    }, [isWeb3Initialized])
 
     if (!isWeb3Initialized) {
         return null

--- a/packages/sdk-shared/lib/interfaces/events.ts
+++ b/packages/sdk-shared/lib/interfaces/events.ts
@@ -37,6 +37,9 @@ export function isPermissionsRequest(args: { method: string; params?: unknown })
     return arrayIncludes(methods, args.method)
 }
 export interface HappyEvents {
+    // called once after iframe has loaded and initialized
+    "iframe-init": boolean
+
     // modal states
     "modal-toggle": boolean
 

--- a/packages/sdk-vanillajs/lib/chains.ts
+++ b/packages/sdk-vanillajs/lib/chains.ts
@@ -1,6 +1,7 @@
 import { chains } from "@happychain/sdk-shared"
 
 export const devnet = chains.devnet
+
 export const testnet = chains.happyChainSepolia
 
 export const defaultChain = chains.defaultChain

--- a/packages/sdk-vanillajs/lib/happy-wallet.ts
+++ b/packages/sdk-vanillajs/lib/happy-wallet.ts
@@ -1,4 +1,4 @@
-import { AuthState, config } from "@happychain/sdk-shared"
+import { AuthState, type UUID, config } from "@happychain/sdk-shared"
 import { LitElement, css, html } from "lit"
 import { customElement } from "lit/decorators.js"
 import { classMap } from "lit/directives/class-map.js"
@@ -15,16 +15,16 @@ function filterUndefinedValues(obj: { [k: string]: string | undefined }): { [k: 
 @customElement("happy-wallet")
 export class HappyWallet extends LitElement {
     static properties = {
-        classes: { state: true },
+        "#classes": { state: true },
     }
 
-    private classes = {
+    #classes = {
         open: false,
         connected: false,
     }
 
     constructor(
-        private windowId: ReturnType<typeof crypto.randomUUID>,
+        private windowId: UUID,
         /** Stringified {@link AddEthereumChainParameter} */
         private chain: string,
         /** Stringified rpc url array string[] */
@@ -37,14 +37,18 @@ export class HappyWallet extends LitElement {
         super.connectedCallback()
 
         onAuthStateUpdate((state) => {
-            this.classes.connected = state === AuthState.Connected
+            this.#classes.connected = state === AuthState.Connected
             this.requestUpdate()
         })
 
         onModalUpdate((isOpen) => {
-            this.classes.open = isOpen
+            this.#classes.open = isOpen
             this.requestUpdate()
         })
+    }
+
+    #onError() {
+        console.error("HappyChain SDK failed to initialize")
     }
 
     render() {
@@ -59,15 +63,16 @@ export class HappyWallet extends LitElement {
         ).toString()
 
         const cssClasses = classMap({
-            open: this.classes.open,
-            closed: !this.classes.open,
-            connected: this.classes.connected,
-            disconnected: !this.classes.connected,
+            open: this.#classes.open,
+            closed: !this.#classes.open,
+            connected: this.#classes.connected,
+            disconnected: !this.#classes.connected,
         })
 
         return html`
             <iframe
                 title="happy-iframe"
+                @error="${this.#onError}"
                 src="${url.href}?${searchParams}"
                 class=${cssClasses}
                 style="border: none;"

--- a/packages/sdk-vanillajs/lib/happyProvider/initialize.ts
+++ b/packages/sdk-vanillajs/lib/happyProvider/initialize.ts
@@ -1,5 +1,5 @@
 import type { EIP1193ProxiedEvents, HappyEvents, HappyUser } from "@happychain/sdk-shared"
-import { EventBus, EventBusChannel, config, createUUID } from "@happychain/sdk-shared"
+import { EventBus, EventBusChannel, config, createUUID, waitForCondition } from "@happychain/sdk-shared"
 import type { EIP1193Provider } from "viem"
 import { HappyProvider } from "./happyProvider"
 import { registerListeners } from "./listeners"
@@ -16,7 +16,13 @@ const dappMessageBus = new EventBus<HappyEvents>({
     scope: "happy-chain-dapp-bus",
 })
 
-export const { onUserUpdate, onModalUpdate, onAuthStateUpdate } = registerListeners(dappMessageBus)
+export const { onUserUpdate, onModalUpdate, onAuthStateUpdate, onIframeInit } = registerListeners(dappMessageBus)
+
+let iframeReady = false
+
+onIframeInit((ready: boolean) => {
+    iframeReady = ready
+})
 
 let user: HappyUser | undefined
 
@@ -37,7 +43,12 @@ onUserUpdate((_user?: HappyUser) => {
  * const user = getCurrentUser()
  * ```
  */
-export const getCurrentUser = () => user
+export const getCurrentUser = () => {
+    if (!iframeReady) {
+        console.warn("getCurrentUser was called before happychain-sdk was ready. result will be empty")
+    }
+    return user
+}
 
 /**
  * `happyProvider` is an {@link https://eips.ethereum.org/EIPS/eip-1193 | EIP1193 Ethereum Provider}

--- a/packages/sdk-vanillajs/lib/happyProvider/listeners.ts
+++ b/packages/sdk-vanillajs/lib/happyProvider/listeners.ts
@@ -13,6 +13,9 @@ export type ModalUpdateCallback = (isOpen: boolean) => void
 /** @internal */
 export type AuthStateUpdateCallback = (state: AuthState) => void
 
+/** @internal */
+export type IframeInitCallback = (isInit: boolean) => void
+
 /**
  * Cleanup function which can be used to unsubscribe
  * from the event which it was returned from
@@ -30,6 +33,7 @@ export type ListenerUnsubscribeFn = () => void
 export function registerListeners(messageBus: EventBus<HappyEvents>) {
     const onUserUpdateCallbacks = new Set<UserUpdateCallback>()
     const onModalUpdateCallbacks = new Set<ModalUpdateCallback>()
+    const onIframeInitCallbacks = new Set<IframeInitCallback>()
     const onAuthStateUpdateCallbacks = new Set<AuthStateUpdateCallback>()
 
     messageBus.on("auth-changed", (user) => {
@@ -47,6 +51,12 @@ export function registerListeners(messageBus: EventBus<HappyEvents>) {
     messageBus.on("modal-toggle", (isOpen) => {
         for (const call of onModalUpdateCallbacks) {
             call(isOpen)
+        }
+    })
+
+    messageBus.on("iframe-init", (isInit) => {
+        for (const call of onIframeInitCallbacks) {
+            call(isInit)
         }
     })
 
@@ -99,9 +109,24 @@ export function registerListeners(messageBus: EventBus<HappyEvents>) {
         }
     }
 
+    /**
+     * Called when the iframe finishes initializing and web3 connection is confirmed
+     *
+     * @internal
+     * @param IframeInitCallback
+     * @returns Unsubscribe function
+     */
+    const onIframeInit = (callback: IframeInitCallback): ListenerUnsubscribeFn => {
+        onIframeInitCallbacks.add(callback)
+        return () => {
+            onIframeInitCallbacks.delete(callback)
+        }
+    }
+
     return {
         onUserUpdate,
         onModalUpdate,
         onAuthStateUpdate,
+        onIframeInit,
     }
 }


### PR DESCRIPTION
### TL;DR

Added iframe initialization event and improved error handling in the HappyChain SDK.

### What changed?

- Introduced an "iframe-init" event in the HappyEvents interface.
- Added an effect in HappyAccountProvider to emit the "iframe-init" event when web3 is initialized.
- Implemented error handling for iframe initialization in the HappyWallet component.
- Updated the getCurrentUser function to warn if called before the SDK is ready.
- Added an onIframeInit listener to track the SDK's initialization state.

### How to test?

1. Integrate the updated SDK into a test application.
2. Monitor the console for any warnings when calling getCurrentUser before the SDK is fully initialized.
3. Verify that the "iframe-init" event is emitted correctly when the iframe is loaded and web3 is initialized.
4. Test error scenarios by intentionally causing the iframe to fail loading and check if the error is logged.

### Why make this change?

This change improves the reliability and user experience of the HappyChain SDK by:

1. Providing a clear signal when the SDK is fully initialized and ready for use.
2. Preventing potential issues caused by accessing SDK functions before it's ready.
3. Enhancing error handling to help developers identify and troubleshoot integration issues more easily.
4. Ensuring that applications using the SDK can properly synchronize their behavior with the SDK's initialization state.

---

