### PR TITLE
experimental - disable rollupTypes on build

### DIFF
--- a/packages/demo-react/package.json
+++ b/packages/demo-react/package.json
@@ -14,6 +14,7 @@
     },
     "devDependencies": {
         "@happychain/configs": "workspace:^",
+        "@types/bun": "^1.1.8",
         "@types/react": "^18.3.4",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react-swc": "^3.7.0",

--- a/packages/demo-react/tsconfig.app.json
+++ b/packages/demo-react/tsconfig.app.json
@@ -2,8 +2,9 @@
     "extends": "@happychain/configs/tsconfig.vite-lib.json",
     "compilerOptions": {
         "paths": {
-            "@happychain/react": ["../sdk-react/lib/index"]
+            "@happychain/react": ["../sdk-react/lib/index"],
+            "@happychain/js": ["../sdk-vanillajs/lib/index"]
         }
     },
-    "include": ["src", "../sdk-react/lib"]
+    "include": ["src", "../sdk-react/lib", "../sdk-vanillajs/lib"]
 }

--- a/packages/demo-react/vite.config.ts
+++ b/packages/demo-react/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     resolve: {
         alias: {
             "@happychain/react": resolve(__dirname, "../sdk-react/lib/index.ts"),
+            "@happychain/reacjst": resolve(__dirname, "../sdk-vanillajs/lib/index.ts"),
         },
     },
 })

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -6,10 +6,10 @@
     "files": ["dist"],
     "main": "./dist/index.umd.js",
     "module": "./dist/index.es.js",
-    "types": "./dist/index.d.ts",
+    "types": "./dist/sdk-react/lib/index.d.ts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.ts",
+            "types": "./dist/sdk-react/lib/index.d.ts",
             "import": "./dist/index.es.js",
             "require": "./dist/index.umd.js"
         }

--- a/packages/sdk-react/vite.config.ts
+++ b/packages/sdk-react/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     plugins: [
         dts({
             // nicer output, but takes time
-            insertTypesEntry: true,
+            insertTypesEntry: false,
             // rollup types doesn't support 'as const'
             // https://github.com/microsoft/rushstack/issues/3875
             rollupTypes: false,
@@ -37,13 +37,7 @@ export default defineConfig({
             compilerOptions: {
                 rootDir: "../",
             },
-            bundledPackages: [
-                "@happychain/js",
-                "viem",
-                "abitype",
-                "@metamask/safe-event-emitter",
-                "@happychain/sdk-shared",
-            ],
+            bundledPackages: ["viem", "abitype", "@metamask/safe-event-emitter", "@happychain/sdk-shared"],
             tsconfigPath: "tsconfig.app.json",
             exclude: ["**/*.test.tsx", "**/*.test.ts"],
         }),

--- a/packages/sdk-shared/lib/interfaces/eip1193.ts
+++ b/packages/sdk-shared/lib/interfaces/eip1193.ts
@@ -53,7 +53,10 @@ const eip1193PermissionsMethodsSet = new Set<string>(eip1193PermissionsMethods)
 /**
  * Union type of all EIP1193 request types that request permissions.
  */
-export type EIP1193PermissionsRequest = Extract<EIP1193RequestParameters, { method: typeof eip1193PermissionsMethods }>
+export type EIP1193PermissionsRequest = Extract<
+    EIP1193RequestParameters,
+    { method: (typeof eip1193PermissionsMethods)[number] }
+>
 
 /**
  * Checks if the EIP-1193 request is one that requests permissions.

--- a/packages/sdk-vanillajs/package.json
+++ b/packages/sdk-vanillajs/package.json
@@ -6,10 +6,10 @@
     "files": ["dist"],
     "main": "./dist/index.umd.js",
     "module": "./dist/index.es.js",
-    "types": "./dist/index.es.d.ts",
+    "types": "./dist/sdk-vanillajs/lib/index.d.ts",
     "exports": {
         ".": {
-            "types": "./dist/index.es.d.ts",
+            "types": "./dist/sdk-vanillajs/lib/index.d.ts",
             "import": "./dist/index.es.js",
             "require": "./dist/index.umd.js"
         }

--- a/packages/sdk-vanillajs/vite.config.ts
+++ b/packages/sdk-vanillajs/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(({ mode }) => {
                 presets: [presets.lit],
             }),
             dts({
-                insertTypesEntry: true,
+                insertTypesEntry: false,
                 // rollup types doesn't support 'as const'
                 // https://github.com/microsoft/rushstack/issues/3875
                 rollupTypes: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@happychain/configs':
         specifier: workspace:^
         version: link:../configs
+      '@types/bun':
+        specifier: ^1.1.8
+        version: 1.1.8
       '@types/react':
         specifier: ^18.3.4
         version: 18.3.4
@@ -6084,7 +6087,6 @@ packages:
     resolution: {integrity: sha512-Quz3MvAwHxVYNXsOByL7xI5EB2WYOeFswqaHIA3qOK3isRWTxiplBEocmmru6XmxDB2L7jDNYtYA4FyimoAFEw==}
     engines: {node: '>=8.17.0'}
     hasBin: true
-    bundledDependencies: []
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}


### PR DESCRIPTION
Disabled rollup types

Pros:
- can use `as const`
- much faster builds (sdk-js went from 33s to 17s in one test run)

Cons:
- many d.ts fils instead of a single exported one

We also have `insertTypesEntry` enabled though which creates an initial `index.d.ts` which just re-exports all types, so i think in practice, there will be not much difference.