### PR TITLE
allow clipboard read / write in iframe

### DIFF
--- a/packages/sdk-vanillajs/lib/happy-wallet.ts
+++ b/packages/sdk-vanillajs/lib/happy-wallet.ts
@@ -110,8 +110,8 @@ export class HappyWallet extends LitElement {
         }
 
         iframe.connected.open {
-            height: 500px;
-            width: 500px;
+            height: 20rem;
+            width: 20rem;
             border-radius: 0.5rem;
             overflow: hidden;
         }


### PR DESCRIPTION
Adds the `allow="clipboard-read; clipboard-write"` attribute to the iframe, enabling clipboard access for embedded content.

ref: https://stackoverflow.com/questions/61401384/can-text-within-an-iframe-be-copied-to-clipboard/65547902#65547902