### PR TITLE
add mipd utility to announce happyProvider

### DIFF
--- a/packages/sdk-vanillajs/lib/happyProvider/initialize.ts
+++ b/packages/sdk-vanillajs/lib/happyProvider/initialize.ts
@@ -102,7 +102,7 @@ export const unsubscribe = announceProvider({
     info: {
         icon: 'data:image/svg+xml,<svg width="32px" height="32px" viewBox="0 0 32 32"/>',
         name: "HappyWallet",
-        rdns: "com.example",
+        rdns: "tech.happy",
         uuid: createUUID(),
     },
     provider: happyProvider,


### PR DESCRIPTION
Installs `mipd` package to support EIP-6963 capabilities for HappyProvider. 

### Testing method: 

tested the following code snippets in the browser console: 

```
window.addEventListener(
  "eip6963:announceProvider",
  (event) => { console.log({ event  }) }
);
```

```
window.dispatchEvent(new Event("eip6963:requestProvider"));
```

happyProvider instance was logged in the response event: 
![Screenshot 2024-09-12 at 3 25 03 PM](https://github.com/user-attachments/assets/7a72c1a9-4f17-40b0-9b30-73452ccf8e92)


