### PR TITLE
improve makefile help system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,6 @@ endif
 
 include makefiles/lib.mk
 
-help: ## Show this help
-	@echo ""
-	@echo "Specify a command. The choices are:"
-	@echo ""
-	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[0;36m%-12s\033[m %s\n", $$1, $$2}'
-	@echo ""
-.PHONY: help
 
 # ==================================================================================================
 # Packages
@@ -71,9 +64,6 @@ deploy: ## Deploys contracts to Anvil
 build: node_modules ts.build  ## Creates production builds
 .PHONY: build
 
-docs: node_modules docs.contained ## Builds latest docs and starts dev server http://localhost:4173
-	cd packages/docs && make preview
-.PHONY: docs
 
 check: node_modules ts.check contracts.check ## Runs code quality & formatting checks
 	@# cf. makefiles/formatting.mk
@@ -87,50 +77,48 @@ format: ts.format contracts.format ## Formats code and tries to fix code quality
 test: sdk.test iframe.test ## Run tests
 .PHONY: test
 
-clean: ts.clean contracts.clean ## Removes build artifacts
-.PHONY: clean
-
 nuke: remove-modules clean ## Removes build artifacts and dependencies
 	cd packages/contracts && make nuke
 	cd packages/bundler && make nuke
 .PHONY: nuke
 
+docs: node_modules docs.contained ## Builds latest docs and starts dev server http://localhost:4173
+	cd packages/docs && make preview
+.PHONY: docs
+
+iframe.dev: shared.dev sdk.dev ## Serves the wallet iframe at http://localhost:5160
+	cd packages/iframe && make dev
+.PHONY: iframe.dev
+
+demo-js.dev: setup shared.dev sdk.dev ## Serves the VanillaJS demo application as http://localhost:5173
+	$(MULTIRUN) --names "iframe,demo-js" "cd packages/iframe && make dev" "cd packages/demo-vanillajs && make dev"
+.PHONY: demo-js.dev
+
+demo-react.dev: setup shared.dev sdk.dev ## Serves the React demo application as http://localhost:5173
+	$(MULTIRUN) --names "iframe,demo-react" "cd packages/iframe && make dev" "cd packages/demo-react && make dev"
+.PHONY: demo-react.dev
+
+demo-vue.dev: setup shared.dev sdk.dev ## Serves the VueJS demo application as http://localhost:5173
+	$(MULTIRUN) --names "iframe,demo-vue" "cd packages/iframe && make dev" "cd packages/demo-wagmi-vue && make dev"
+.PHONY: demo-vue.dev
+
 # ==================================================================================================
 # DEVELOPMENT
 
-iframe-dev-command := cd packages/iframe && make dev
-
-sdk.dev:
-	@# intentially building sequentially. 
-	@# get sporadic build errors when in parralel and starting demos
+shared.dev:
 	cd packages/common && make build
 	cd packages/sdk-shared && make build
+	cd packages/vite-plugin-shared-worker && make build
+.PHONY: shared.dev
+
+sdk.dev:
 	cd packages/sdk-frontend-components && make dev
 	cd packages/sdk-vanillajs && make dev
 	cd packages/sdk-react && make dev
 .PHONY: sdk-dev
 
-iframe.dev:
-	$(iframe-dev-command)
-.PHONY: iframe.dev
-
-demo-js.dev: setup
-	make sdk.dev;
-	$(MULTIRUN) --names "iframe,demo-js" "$(iframe-dev-command)" "cd packages/demo-vanillajs && make dev"
-.PHONY: demo-js.dev
-
-demo-react.dev: setup
-	make sdk.dev;
-	$(MULTIRUN) --names "iframe,demo-react" "$(iframe-dev-command)" "cd packages/demo-react && make dev"
-.PHONY: demo-react.dev
-
-demo-vue.dev: setup
-	make sdk.dev;
-	$(MULTIRUN) --names "iframe,demo-vue" "$(iframe-dev-command)" "cd packages/demo-wagmi-vue && make dev"
-.PHONY: demo-vue.dev
-
 # start docs in watch mode (can crash, see packages/docs/Makefile for more info)
-docs.dev:
+docs.dev: shared.dev sdk.dev
 	cd packages/docs && make dev
 .PHONY: docs.watch
 
@@ -266,12 +254,15 @@ docs.contained: setup shared.build sdk.dev
 .PHONY: docs.contained
 
 # Serve already-built docs
-docs.preview:
+docs.preview: docs.contained
 	cd packages/docs && make preview
 .PHONY: docs.preview
 
 # ==================================================================================================
 # CLEANING
+
+clean: ts.clean contracts.clean
+.PHONY: clean
 
 sdk.clean:
 	$(call forall_make , $(SDK_PKGS) , clean)

--- a/makefiles/formatting.mk
+++ b/makefiles/formatting.mk
@@ -1,7 +1,7 @@
-check:
+check: ## Runs code quality & formatting checks
 	@biome check ./;
 .PHONT: check
 
-format:
+format: ## Formats code and tries to fix code quality issues
 	@biome check ./ --write;
 .PHONT: format

--- a/makefiles/lib.mk
+++ b/makefiles/lib.mk
@@ -29,6 +29,22 @@ endif
 # Name of the package the makefile is executed for (based on the current directory).
 PKG := $(notdir $(shell pwd))
 
+# Follows all makefile includes to supply help where needed
+# Make sure to include 'lib.mk' as the first include 
+# so that naked `make` runs help!
+help: ## Show this help
+	@echo ""
+	@echo -e "  \033[0;36m$$(bunx figlet $$(bun --print "require('./package.json').name"))\033[0m"
+	@echo ""
+	@echo "  Usage: make <command>"
+	@echo "  Check ./$(firstword $(MAKEFILE_LIST)) for the full list of available commands."
+	@echo ""
+	@echo "  Specify a command. The suggested choices are:"
+	@echo ""
+	@grep -E '^[\.0-9a-zA-Z_-]+:.*?## .*$$' $(wordlist 2,$(words $(MAKEFILE_LIST)), $(MAKEFILE_LIST)) $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = "^[^:]*:"}; {printf $$2 "\n"}' | awk 'BEGIN {FS = ":.*?## "}; {printf "    \033[0;36m%-18s\033[m %s\n", $$1, $$2}'
+.PHONY: help
+
+
 # Empty Stubs — these can be overriden in any including Makefile.
 
 build:

--- a/makefiles/migration.mk
+++ b/makefiles/migration.mk
@@ -1,11 +1,11 @@
-migration-generate:
+migration-generate: ## Generates a new Migration
 	mikro-orm migration:create;
 .PHONY: migration-generate
 
-migration-up:
+migration-up: ## Runs Migrations
 	mikro-orm migration:up;
 .PHONY: migration-up
 
-migration-down:
+migration-down: ## Reverts Migrations
 	mikro-orm migration:down;
 .PHONY: migration-down

--- a/makefiles/simple-ts.mk
+++ b/makefiles/simple-ts.mk
@@ -1,10 +1,10 @@
 # Fragment to be imported for Makefiles that do not need bundling (as handled by the
 # happyBuild script). This includes backend packages and frontend support packages.
 
-build: node_modules dist
+build: node_modules dist ## Builds package with TSC
 .PHONY: build
 
-clean:
+clean: ## Removes build artifacts
 	@rm -rf dist
 	@rm -rf node_modules/.tmp
 .PHONY: clean

--- a/makefiles/vite.mk
+++ b/makefiles/vite.mk
@@ -1,7 +1,7 @@
 TSC_BIN ?= tsc
 
 # Like build.watch but also serves the page on localhost if applicable
-dev: node_modules
+dev: node_modules ## Serves or bundles the package in watch mode
 	@if [[ -r index.html ]]; then \
 	  concurrently --prefix=none "make build.watch" "vite"; \
 	else \
@@ -9,10 +9,10 @@ dev: node_modules
 	fi
 .PHONY: dev
 
-build: node_modules dist
+build: node_modules dist ## Builds the vite application
 .PHONY: build
 
-clean:
+clean:  ## Removes build artifacts
 	@rm -rf dist
 	@rm -rf node_modules/.tmp
 	@rm -rf node_modules/.vite # this sometimes gets corrupted ("cannot load vite.config.ts")
@@ -23,7 +23,7 @@ build.watch: node_modules
 	@$(TSC_BIN) --build --watch --preserveWatchOutput;
 .PHONY: build.watch
 
-preview: node_modules dist
+preview: node_modules dist ## Serves the production mode package
 	@bunx --bun vite preview;
 .PHONY: preview
 

--- a/packages/docs/Makefile
+++ b/packages/docs/Makefile
@@ -7,7 +7,7 @@ include ../../makefiles/formatting.mk
 #
 # Also using concurrently rather than `make -j 3` for the same reason: concurrently restarts
 # the three processes as a group if one crashes.
-dev:
+dev: ## Serves the docs in watch mode
 	concurrently \
 		--restart-tries -1 \
 		--names "doc-js,doc-react,vocs" \
@@ -17,18 +17,18 @@ dev:
 .PHONY: dev
 
 # precompile API reference docs, then build full vocs output
-build: typedoc vocs
+build: typedoc vocs ## Generates the latest docs from source code
 .PHONY: build
 
-clean:
+clean:  ## Removes build artifacts
 	rm -rf docs/dist
 	rm -rf docs/pages/{js,react}/api
 	rm -rf vocs.config.ts.timestamp-*
 	rm -rf node_modules/.tmp
 .PHONY: clean
 
-# Preview production build (run build first)
-preview:
+# Preview production build
+preview: build ## Builds and previews the latest docs
 	vocs preview;
 .PHONY: preview
 
@@ -43,7 +43,7 @@ vocs.watch:
 .PHONY: vocs.watch
 
 # generate all markdown API reference
-typedoc:
+typedoc: ## Generates the markdown files from package source code
 	concurrently --names "js,react"\
 		'make typedoc-js'\
 		'make typedoc-react';

--- a/packages/iframe/Makefile
+++ b/packages/iframe/Makefile
@@ -2,10 +2,10 @@ include ../../makefiles/lib.mk
 include ../../makefiles/vite.mk
 include ../../makefiles/formatting.mk
 
-test:
+test: ## Runs tests
 	vitest run
 .PHONY: test
 
-test.watch:
+test.watch: ## Runs tests in watch mode
 	vitest watch
 .PHONY: test.watch

--- a/packages/sdk-frontend-components/Makefile
+++ b/packages/sdk-frontend-components/Makefile
@@ -2,7 +2,7 @@ include ../../makefiles/lib.mk
 include ../../makefiles/formatting.mk
 include ../../makefiles/bundling.mk
 
-dev:: node_modules
+dev:: node_modules 
 	@ln -s ../lib/badge.tsx ./dist/preact.es.js
 	@ln -s ../lib/badge.tsx ./dist/preact.es.d.ts
 .PHONY: dev

--- a/packages/sdk-shared/Makefile
+++ b/packages/sdk-shared/Makefile
@@ -2,6 +2,6 @@ include ../../makefiles/lib.mk
 include ../../makefiles/formatting.mk
 include ../../makefiles/simple-ts.mk
 
-test:
-	bun test .
+test: ## Runs Tests
+	@bun test .
 .PHONY: test

--- a/packages/sdk-vanillajs/Makefile
+++ b/packages/sdk-vanillajs/Makefile
@@ -2,6 +2,6 @@ include ../../makefiles/lib.mk
 include ../../makefiles/formatting.mk
 include ../../makefiles/bundling.mk
 
-test:
+test: ## Runs Tests
 	@bun test .
 .PHONY: test


### PR DESCRIPTION
### TL;DR

Improved Makefile structure and documentation across the project.

### What changed?

- All makefiles that include 'lib.mk' now get help commands out of the box
- Help commands now follow and makefile which has been 'included'
- Reorganized and standardized Makefile targets across packages
- Added help text to Makefile targets for better documentation
- Improved the `help` target to display a more informative and visually appealing output
- Consolidated and streamlined development-related targets
- Added new targets for shared development and documentation tasks
- Updated package.json to include a `help` script

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/0a7e5878-96ee-4cfc-b978-360d9bcc160e.png)


![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/220d20df-e05f-4a32-b4d0-9efc29021dfa.png)

