### PR TITLE
vite-plugin-shim-worker

### DIFF
--- a/packages/iframe/vite.config.ts
+++ b/packages/iframe/vite.config.ts
@@ -10,9 +10,7 @@ export default defineConfig({
     plugins: [
         nodePolyfills({ globals: { Buffer: true } }), // required for web3Auth
         TanStackRouterVite(),
-        react({
-            babel: { presets: ["jotai/babel/preset"] },
-        }),
+        react({ babel: { presets: ["jotai/babel/preset"] } }),
     ],
     resolve: {
         alias: {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,7 +1,35 @@
 import type { Plugin } from "vite"
 import { DevelopmentPlugin } from "./plugin/DevelopmentPlugin"
-import { ProductionClientPlugin } from "./plugin/ProductionClientPlugin"
+import { SharedWorkerClientPlugin } from "./plugin/SharedWorkerClientPlugin"
+import { SharedWorkerShimPlugin } from "./plugin/SharedWorkerShimPlugin"
 
-export function SharedWorkerPlugin(): Plugin[] {
-    return [DevelopmentPlugin(), ProductionClientPlugin()]
+type Options = {
+    /**
+     * When true, uses the SharedWorkerShimPlugin & SharedWorkerShim
+     * instead of true SharedWorker or WebWorkers. This can be helpful for
+     * debugging misbehaving workers, as it simply injects the expected Worker API
+     * into the worker module, but runs the file locally instead so that things such
+     * as console.log will work as they do when not in a shared worker context.
+     */
+    disabled?: boolean
+}
+
+/**
+ * SharedWorkerPlugin
+ *
+ * Converts .ws.ts modules into an RPC based SharedWorker for easier use.
+ */
+export function SharedWorkerPlugin({ disabled = false }: Options = {}): Plugin[] {
+    return disabled //
+        ? [
+              // injects 'worker' interface to server,
+              // and exposes compatible exports to client
+              SharedWorkerShimPlugin(),
+          ]
+        : [
+              // only impacts 'serve' command, i.e. 'vite'
+              DevelopmentPlugin(),
+              // only impacts 'build' command i.e. 'vite build'
+              SharedWorkerClientPlugin(),
+          ]
 }

--- a/packages/worker/src/plugin/SharedWorkerClientPlugin.ts
+++ b/packages/worker/src/plugin/SharedWorkerClientPlugin.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from "vite"
 import pkg from "../../package.json"
-import { ProductionWorkerPlugin } from "./ProductionWorkerPlugin"
+import { SharedWorkerServerPlugin } from "./SharedWorkerServerPlugin"
 import { clientCodeGen } from "./codegen"
 import { filter } from "./utils"
 
@@ -14,7 +14,7 @@ import { filter } from "./utils"
  * vite will follow that import as a [Worker](https://vite.dev/config/worker-options)
  * and the worker plugin will be executed handling the worker-side generation
  */
-export function ProductionClientPlugin(): Plugin {
+export function SharedWorkerClientPlugin(): Plugin {
     return {
         name: `${pkg.name}:client`,
         apply: "build",
@@ -22,7 +22,7 @@ export function ProductionClientPlugin(): Plugin {
         config() {
             return {
                 // inject production worker plugin
-                worker: { format: "es", plugins: () => [ProductionWorkerPlugin()] },
+                worker: { format: "es", plugins: () => [SharedWorkerServerPlugin()] },
             }
         },
         transform(code: string, id: string) {

--- a/packages/worker/src/plugin/SharedWorkerServerPlugin.ts
+++ b/packages/worker/src/plugin/SharedWorkerServerPlugin.ts
@@ -12,7 +12,7 @@ import { filter } from "./utils"
  * and handles the RPC functionality, managing requests and responses between
  * server and clients
  */
-export function ProductionWorkerPlugin(): Plugin {
+export function SharedWorkerServerPlugin(): Plugin {
     return {
         name: `${pkg.name}:worker`,
         apply: "build",

--- a/packages/worker/src/plugin/SharedWorkerShimPlugin.ts
+++ b/packages/worker/src/plugin/SharedWorkerShimPlugin.ts
@@ -1,0 +1,32 @@
+import type { Plugin } from "vite"
+import pkg from "../../package.json"
+import { shimCodeGen } from "./codegen"
+import { filter } from "./utils"
+
+/**
+ * Plugin can run during both the 'build' or 'serve' commands, i.e. 'bun vite build' and 'bun vite'
+ *
+ * Injects familiar worker interface into the 'worker' file
+ * however runs in the local context without any worker
+ * as if you just imported the file directly.
+ */
+export function SharedWorkerShimPlugin(): Plugin {
+    return {
+        name: `${pkg.name}:shim`,
+        enforce: "pre",
+        config(_config, env) {
+            if (env.command === "serve") {
+                return {
+                    build: {
+                        // required to avoid `"addMessageListener" is not exported by` type errors
+                        rollupOptions: { preserveEntrySignatures: "strict" },
+                    },
+                }
+            }
+        },
+        transform(code: string, id: string) {
+            if (!filter(id)) return
+            return { code: shimCodeGen(code, id) }
+        },
+    }
+}

--- a/packages/worker/src/plugin/codegen.ts
+++ b/packages/worker/src/plugin/codegen.ts
@@ -41,3 +41,14 @@ export function workerCodeGen(code: string, id: string) {
         + `// ${pkg.name} ends\n`
         + code
 }
+
+export function shimCodeGen(code: string, _id: string) {
+    // biome-ignore format: tidy
+    return ""
+        + "// ${pkg.name} starts\n"
+        + "import { SharedWorkerShim } from '${pkg.name}/runtime'\n"
+        + "const worker = new SharedWorkerShim()\n"
+        + "export const addMessageListener = worker.addMessageListener.bind(worker)\n"
+        + "// ${pkg.name} ends\n"
+        + code
+}

--- a/packages/worker/src/runtime/index.ts
+++ b/packages/worker/src/runtime/index.ts
@@ -2,6 +2,8 @@ export { SharedWorkerClient } from "./client"
 
 export { SharedWorkerServer } from "./server"
 
+export { SharedWorkerShim } from "./shim"
+
 export * from "./types"
 
 export * from "./payload"

--- a/packages/worker/src/runtime/interface.ts
+++ b/packages/worker/src/runtime/interface.ts
@@ -1,0 +1,8 @@
+import type { MessageCallback } from "./types"
+
+export interface ServerInterface {
+    ports(): MessagePort[]
+    dispatch(port: MessagePort, data: unknown): void
+    addMessageListener<T>(fn: MessageCallback<T>): void
+    broadcast(data: unknown): void
+}

--- a/packages/worker/src/runtime/server.ts
+++ b/packages/worker/src/runtime/server.ts
@@ -1,4 +1,6 @@
 /// <reference lib="WebWorker" />
+
+import type { ServerInterface } from "./interface"
 import { makeBroadcastPayload, makeConsolePayload, makeRpcPayload, parsePayload } from "./payload"
 import type { MessageCallback } from "./types"
 
@@ -19,7 +21,7 @@ const genName = () => `SharedWorker-${crypto.randomUUID()}`
  * The public functions of this class can also be used to exchange arbitrary (but serializable)
  * messages between the worker and its clients.
  */
-export class SharedWorkerServer {
+export class SharedWorkerServer implements ServerInterface {
     // maps heartbeat ports to the latest heartbeat
     private readonly _ports = new Map<MessagePort, number>()
     private readonly _functions = new Map<string, Fn>()

--- a/packages/worker/src/runtime/shim.ts
+++ b/packages/worker/src/runtime/shim.ts
@@ -1,0 +1,38 @@
+/// <reference lib="WebWorker" />
+
+import type { ServerInterface } from "./interface"
+import type { MessageCallback } from "./types"
+
+/**
+ * SharedWorkerShim
+ *
+ * This file prepares a locally imported file (no worker) to expose the same API
+ * as SharedWorkerServer. This allows for easier debugging in some situations
+ * (i.e. console.log always works) without any user-land code modifications.
+ *
+ * methods such as worker.broadcast(...) will continue to function as expected
+ * as if they where executing in a shared worker context
+ */
+export class SharedWorkerShim implements ServerInterface {
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    private _messageCallbacks = new Set<MessageCallback<any>>()
+
+    ports() {
+        return []
+    }
+    dispatch(_: MessagePort, data: unknown) {
+        for (const cb of this._messageCallbacks) {
+            cb(data)
+        }
+    }
+
+    addMessageListener<T>(fn: MessageCallback<T>) {
+        this._messageCallbacks.add(fn)
+    }
+
+    broadcast(data: unknown) {
+        for (const cb of this._messageCallbacks) {
+            cb(data)
+        }
+    }
+}

--- a/packages/worker/src/runtime/types.ts
+++ b/packages/worker/src/runtime/types.ts
@@ -1,1 +1,1 @@
-export type MessageCallback<T> = (this: Event, data: T) => void | Promise<void>
+export type MessageCallback<T> = (data: T) => void | Promise<void>


### PR DESCRIPTION
### TL;DR

Added a new WorkerShimPlugin and introduced a disabled option for SharedWorkerPlugin.

### What changed?

- Introduced a new `WorkerShimPlugin` that injects a familiar worker interface into the 'worker' file, running in the local context without an actual worker.
- Added a `disabled` option to the `SharedWorkerPlugin` function, which when set to true, uses the `WorkerShimPlugin` instead of the development and production plugins.
- Created new files: `WorkerShimPlugin.ts`, `interface.ts`, and `shim.ts` to support the new functionality.
- Updated the `codegen.ts` file to include a `shimsCodeGen` function for generating shim code.
- Modified the `types.ts` file to update the `MessageCallback` type signature.
- Updated the `worker.ts` file to implement the new `ServerInterface`.

### How to test?

1. Import the `SharedWorkerPlugin` in your Vite configuration.
2. Test the plugin with `disabled: false` (default behavior):
   ```javascript
   SharedWorkerPlugin()
   ```
3. Test the plugin with `disabled: true` to use the new WorkerShimPlugin:
   ```javascript
   SharedWorkerPlugin({ disabled: true })
   ```
4. Verify that the worker behaves correctly in both scenarios, especially checking that the shim version runs in the local context without creating an actual worker.

### Why make this change?

This change provides more flexibility in how the SharedWorkerPlugin is used. The new `disabled` option allows developers to easily switch between using actual workers and a local context simulation. This can be particularly useful for testing, debugging, or in environments where web workers are not supported or desired.