### PR TITLE
remove-todo

### DIFF
--- a/packages/demo-wagmi-vue/src/wagmi.ts
+++ b/packages/demo-wagmi-vue/src/wagmi.ts
@@ -17,7 +17,6 @@ import { injected } from "@wagmi/vue/connectors"
 // biome-ignore lint/suspicious/noExplicitAny: demo purposes only. not needed under regular usage
 ;(window as any).happyProvider = happyProvider
 
-// TODO:
 export const happyConnector = injected({
     shimDisconnect: false,
     target() {


### PR DESCRIPTION
## Not ready for review

- [x] My branch is named `<my-prefix>/<short-descriptor>` (e.g. `aryan/paymaster-gas`).
- [x] I have prefixed my PR title with “\[draft\] “ (keep this checked after the review is ready
       for PR)
- [x] This PR will not end up being too big.
- [x] This PR addresses only one concern and not unrelated concerns that could be handled in
       separate PRs.
- [x] This PR is targetted correctly (it is stacked onto `master` or the lowest PR whose
       functionality it absolutely needs or would cause lots of conflicts with)

## After a review

- [x]  I am well-aware of the [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631 

---

Please make sure you tick off everything below (except when there is multi-choice selection) before
requesting a review.

---

## General Checks

- [x] I have run `make build` & `make check` (this should done be the `push` hook)
    - If not, explain what the issue is.
- [x] I have run `make test`
- [x] The feature I have added/modified works.
- [x] Features even remotely connected to what I changed still work
      (e.g. if you change a utility function's logic).
- [x] I have thought of the various relevant flows (fill the subsections belows)
- [x] I have filled the PR description section below.
- Documentation
    - [x] All public-facing APIs are properly documented in code comments.
    - [x] “General” internal APIs are properly documented in code comments  
          (APIs that are expected to be called from a few different places)
    - [x] Any expected questions that someone reading the code are answered in inline comments.
        - Don't go overboard, don't document stuff that is general knowledge about the framework
          and tools we use.
        - Make local reasoning easy: if getting an answer to a reasonable question
          (e.g. “is it safe to call this here?”, “what if this happens at the same time?”)
          requires spelunking in the code, it probably deserves a comment (or a refactor).
    - [x] I have skipped valueless comments (e.g. documenting `grantPermission(permission, user)`
          with “Grants the given permission to the given user”)
        - Exception: public APIs should always have a comment even if redundant.
    - [x] I checked my spelling and remembered that if using multiple sentences I should start them
          with a capital letter and end them with a dot.
- [x] I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code accordingly.
     - [x] I have added PR comments on things that deserved special notice...
     - [x] ... and thought **really hard** about whether that should be a code comment instead.
     - [x] I have asked myself “What would Norswap say?” and reached out when I had a doubt.
- [x] I have made sure my code passes the GitHub CI check.
- [x] I have marked by PR ready for review by removing “\[draft\] “ and explicitly requesting a review.

## Frontend Only

**Delete this section if your code does not affect the frontend whatsoever.**

- I have tested things with the following demo (select at least one):
    - [ ] JS
    - [ ] React
    - [x] Vue

- On the following browsers (select at least one):
    - [x] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Mobile (specify)

## User Interfaction Flows

- no functional changes, rogue comment removal

## Code Flows

- [ ] List below the code flows you have considered (code running with various underlying states,
       things updating while the new/modified code is running).

## PR Description

### Relevant Context

- [ ] List relevant issues with a #-reference for Github and a URL for Linear.  
       If this PR closes an issue, pleasing add a bullet item.
    - “closes #999999” for Github
    - “closes <linear issue URL>” for Linear
- [ ] List other non-trivial links or documentation.  
      e.g. a guide you consulted on a particular technology or flow.
- [ ] Write down relevant context not present in the issues.

### PR Content

useless TODO from the past
