### PR TITLE
authState-cleanup

### DIFF
--- a/packages/iframe/src/connections/GoogleConnector.ts
+++ b/packages/iframe/src/connections/GoogleConnector.ts
@@ -1,9 +1,8 @@
-import { AuthState, type HappyUser, WalletType } from "@happychain/sdk-shared"
+import { type HappyUser, WalletType } from "@happychain/sdk-shared"
 import { connect, disconnect } from "@wagmi/core"
 import { type AuthProvider, GoogleAuthProvider } from "firebase/auth"
 import type { EIP1193Provider } from "viem"
 import { setUserWithProvider } from "#src/actions/setUserWithProvider.ts"
-import { setAuthState } from "#src/state/authState.ts"
 import { getChains } from "#src/state/chains.ts"
 import { grantPermissions } from "#src/state/permissions.ts"
 import { getUser } from "#src/state/user.ts"
@@ -32,13 +31,11 @@ export class GoogleConnector extends FirebaseConnector {
         if (getUser()?.type !== WalletType.Social) return
         await disconnect(config)
         setUserWithProvider(undefined, undefined)
-        setAuthState(AuthState.Disconnected)
     }
 
     async onReconnect(user: HappyUser, provider: EIP1193Provider) {
         setUserWithProvider(user, provider)
         await connect(config, { connector: happyConnector })
-        setAuthState(AuthState.Connected)
     }
 
     async onConnect(user: HappyUser, provider: EIP1193Provider) {
@@ -52,6 +49,5 @@ export class GoogleConnector extends FirebaseConnector {
         setUserWithProvider(user, provider)
         grantPermissions(getAppURL(), "eth_accounts")
         await connect(config, { connector: happyConnector })
-        setAuthState(AuthState.Connected)
     }
 }

--- a/packages/iframe/src/connections/InjectedConnector.ts
+++ b/packages/iframe/src/connections/InjectedConnector.ts
@@ -6,11 +6,10 @@ import type {
     MsgsFromApp,
     MsgsFromIframe,
 } from "@happychain/sdk-shared"
-import { AuthState, EIP1193UserRejectedRequestError, Msgs, WalletType } from "@happychain/sdk-shared"
+import { EIP1193UserRejectedRequestError, Msgs, WalletType } from "@happychain/sdk-shared"
 import { connect, disconnect } from "@wagmi/core"
 import type { EIP1193Provider } from "viem"
 import { setUserWithProvider } from "#src/actions/setUserWithProvider.ts"
-import { setAuthState } from "#src/state/authState.ts"
 import { config } from "#src/wagmi/config.ts"
 import { happyConnector } from "#src/wagmi/connector.ts"
 import { iframeID } from "../requests/utils"
@@ -57,20 +56,17 @@ export class InjectedConnector implements ConnectionProvider {
         setUserWithProvider(user, provider)
         grantPermissions(getAppURL(), "eth_accounts")
         await connect(config, { connector: happyConnector })
-        setAuthState(AuthState.Connected)
     }
 
     public async onReconnect(user: HappyUser, provider: EIP1193Provider) {
         setUserWithProvider(user, provider)
         grantPermissions(getAppURL(), "eth_accounts")
         await connect(config, { connector: happyConnector })
-        setAuthState(AuthState.Connected)
     }
 
     public async onDisconnect() {
         await disconnect(config)
         setUserWithProvider(undefined, undefined)
-        setAuthState(AuthState.Disconnected)
     }
 
     public async connect(req: MsgsFromApp[Msgs.ConnectRequest]): Promise<MsgsFromIframe[Msgs.ConnectResponse]> {

--- a/packages/iframe/src/listeners/atoms.ts
+++ b/packages/iframe/src/listeners/atoms.ts
@@ -1,4 +1,4 @@
-import { AuthState, Msgs } from "@happychain/sdk-shared"
+import { Msgs } from "@happychain/sdk-shared"
 import { getDefaultStore } from "jotai/vanilla"
 import { http, createPublicClient } from "viem"
 import { mainnet } from "viem/chains"
@@ -11,8 +11,9 @@ import { emitUserUpdate } from "../utils/emitUserUpdate"
 const store = getDefaultStore()
 
 /**
- * Runs once at startup to transmit the current auth state to the app (likely
- * {@link AuthState.Disconnected}, or {@link AuthState.Connecting}).
+ * Runs once at startup to transmit the current auth state to the app. Will be one of
+ * {@link AuthState.Disconnected}, or {@link AuthState.Initializing} depending on if a
+ * user is cached in local storage or not
  *
  * @emits {@link Msgs.AuthStateChanged}
  */
@@ -33,9 +34,6 @@ void appMessageBus.emit(Msgs.AuthStateChanged, store.get(authStateAtom))
 store.sub(authStateAtom, () => {
     const authState = store.get(authStateAtom)
     void appMessageBus.emit(Msgs.AuthStateChanged, authState)
-
-    // no user updates in this state
-    if (AuthState.Connecting === authState) return
 
     emitUserUpdate(store.get(userAtom))
 })

--- a/packages/iframe/src/routes/embed.lazy.tsx
+++ b/packages/iframe/src/routes/embed.lazy.tsx
@@ -53,7 +53,7 @@ function Embed() {
 
     useEffect(() => {
         const unsubscribe = appMessageBus.on(Msgs.RequestWalletDisplay, async (screen) => {
-            await waitForCondition(() => getAuthState() !== AuthState.Connecting)
+            await waitForCondition(() => getAuthState() !== AuthState.Initializing)
             switch (screen) {
                 case WalletDisplayAction.Home:
                     void navigate({ to: "/embed" })

--- a/packages/iframe/src/state/authState.ts
+++ b/packages/iframe/src/state/authState.ts
@@ -3,7 +3,7 @@ import { AuthState } from "@happychain/sdk-shared"
 import { atom } from "jotai"
 import { StorageKey, storage } from "../services/storage"
 
-const initialState = storage.get(StorageKey.HappyUser) ? AuthState.Connecting : AuthState.Disconnected
+const initialState = storage.get(StorageKey.HappyUser) ? AuthState.Initializing : AuthState.Disconnected
 
 export const authStateAtom = atom<AuthState>(initialState)
 

--- a/packages/iframe/src/wagmi/provider.ts
+++ b/packages/iframe/src/wagmi/provider.ts
@@ -21,7 +21,7 @@ export class IframeProvider extends BasePopupProvider {
 
     protected override async requiresUserApproval(args: EIP1193RequestParameters): Promise<boolean> {
         // We're logging in or out, wait for the auth state to settle.
-        await waitForCondition(() => getAuthState() !== AuthState.Connecting)
+        await waitForCondition(() => getAuthState() !== AuthState.Initializing)
 
         return checkIfRequestRequiresConfirmation(getIframeURL(), args)
     }

--- a/packages/sdk-shared/lib/interfaces/happyUser.ts
+++ b/packages/sdk-shared/lib/interfaces/happyUser.ts
@@ -35,6 +35,6 @@ export enum WalletType {
 
 export enum AuthState {
     Disconnected = "unauthenticated",
-    Connecting = "loading",
+    Initializing = "initializing",
     Connected = "authenticated",
 }

--- a/packages/sdk-vanillajs/lib/happyProvider/happyProvider.ts
+++ b/packages/sdk-vanillajs/lib/happyProvider/happyProvider.ts
@@ -19,7 +19,7 @@ export class HappyProvider extends SafeEventEmitter implements HappyProviderPubl
 
     private initialized = false
 
-    private authState: AuthState = AuthState.Connecting
+    private authState: AuthState = AuthState.Initializing
     private lastConnectedType: WalletType | undefined
 
     constructor(private config: HappyProviderConfig) {
@@ -66,7 +66,7 @@ export class HappyProvider extends SafeEventEmitter implements HappyProviderPubl
 
     public async request(args: EIP1193RequestParameters): Promise<EIP1193RequestResult> {
         // wait until either authenticated or unauthenticated
-        await waitForCondition(() => this.initialized && this.authState !== AuthState.Connecting)
+        await waitForCondition(() => this.initialized && this.authState !== AuthState.Initializing)
 
         try {
             return await this.activeHandler.request(args)

--- a/packages/sdk-vanillajs/lib/happyProvider/socialWalletHandler.ts
+++ b/packages/sdk-vanillajs/lib/happyProvider/socialWalletHandler.ts
@@ -31,7 +31,7 @@ export class SocialWalletHandler extends BasePopupProvider implements EIP1193Con
 
     private inFlightChecks = new Map<string, InFlightCheck>()
     private user: HappyUser | undefined
-    private authState: AuthState = AuthState.Connecting
+    private authState: AuthState = AuthState.Initializing
 
     constructor(private config: HappyProviderConfig) {
         super(config.windowId)

--- a/packages/sdk-vanillajs/lib/wallet/hooks/useAuthState.ts
+++ b/packages/sdk-vanillajs/lib/wallet/hooks/useAuthState.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from "preact/hooks"
 import { onAuthStateUpdate } from "../../happyProvider/initialize"
 
 export function useAuthState() {
-    const [authState, setAuthState] = useState(AuthState.Connecting)
+    const [authState, setAuthState] = useState(AuthState.Initializing)
     useEffect(() => onAuthStateUpdate(setAuthState), [])
     return { authState }
 }

--- a/packages/sdk-vanillajs/lib/wallet/styles.css
+++ b/packages/sdk-vanillajs/lib/wallet/styles.css
@@ -134,7 +134,7 @@
         transition-duration: 0;
     }
 
-    &[data-auth-state="loading"] {
+    &[data-auth-state="initializing"] {
         background-color: rgb(252 211 77 / 1);
     }
 


### PR DESCRIPTION
### Linked Issues

- closes 192

### Description

Remove 'Connecting' authState

This PR removes 'connecting' auth state. Instead on page load it sets to an initial value of 'initializing'
if a user is found cached from a previous session in local storage. In the wallet, we now disable/enable the buttons
state depending on the useMutation status. for injected wallets, this works great. Currently for firebase this
results in an 8 second delay between rejecting to connect, and the buttons restoring to their original state, however
the visual grayscale is non-blocking, so despite the UI looking disabled, re-clicking still works. I think this is a reasonable tradeoff for now, until we implement a better approach for firebase logins without this arbitrary 8 second delay.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

Tested on React Demo

Manual Testing:
  - open react demo, 
  - press Badge Connect button
  - click await top close
  - open wallet with orb
  - Click rabby without connecting
  - close wallet without connecting (rabby closes, wallet returns to original state)
  - Click Metamask without connecting
  - close wallet (metamask stays open, different from rabby, metamask option remains active)
  - close metamask -> all buttons return to original state
  - click in with google
  - close popup without connecting
    - wait 8 seconds for buttons to restore
    - alternatively, click again to sign in, or even click a different conection option, they still work
  - refresh page while in connected and disconnected states, 

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
