### PR TITLE
feat(iframe): HAPPY-157  - adapt `eth_getTransactionCount`, `eth_getTransactionReceipt` to smart account

### DIFF
--- a/packages/iframe/src/requests/permissionless.ts
+++ b/packages/iframe/src/requests/permissionless.ts
@@ -75,11 +75,11 @@ export async function dispatchHandlers(request: ProviderMsgsFromApp[Msgs.Request
                  * 1. First layer (execute function) :
                  *    The outer wrapper is a call to the `execute()` function (selector: `0xe9ae5c53`)
                  *    We decode this to get :
-                 *    - `execMode`: how to execute the transaction
-                 *    - `executeParamsData`: the actual transaction details (wrapped)
+                 *    - `execMode`: how to execute the wrapped call
+                 *    - `executeParamsData`: parameters for the wrapped call
                  *
-                 * 2. Second layer (transaction details) :
-                 *    Inside `executeParamsData`, we find the real transaction information (to, value, data).
+                 * 2. Second layer (target call) :
+                 *    Inside `executeParamsData`, we find the information of the wrapped call (to, value, data).
                  *
                  * @see {@link https://docs.stackup.sh/docs/useroperation-calldata} for additional explanation
                  * @see {@link https://eips.ethereum.org/EIPS/eip-4337#definitions} for the EIP-4337 specification
@@ -125,8 +125,8 @@ export async function dispatchHandlers(request: ProviderMsgsFromApp[Msgs.Request
                     to,
 
                     // Not to be confused with `txReceipt.transactionHash`
-                    // `hash` is the hash of the userop transaction
-                    //  `txReceipt.transactionHash` is the hash of the bundled transaction that includes this userop
+                    // -`hash` is the hash of the userop
+                    // - `txReceipt.transactionHash` is the hash of the bundler transaction that includes this userop
                     transactionHash: hash,
                     transactionIndex,
                     type,


### PR DESCRIPTION
### Linked Issues

- closes [HAPPY-157
](https://linear.app/happychain/issue/HAPPY-157/adapt-eth-gettransactioncount-eth-gettransactionreceipt-to-smart)

- Linked to : 
  -  [HAPPY-158](https://linear.app/happychain/issue/HAPPY-158/implement-eth-sendtransaction-and-eth-estimategas-for-smart-accounts)  (adapt `eth_sendTransaction`, `eth_estimateGas` to smart accounts);
  - [HAPPY-156](https://linear.app/happychain/issue/HAPPY-156/regular-tx-to-userop-translation) (convert transaction to userOp format);
  - [HAPPY-155](https://linear.app/happychain/issue/HAPPY-155/create-smart-account-client-expose-smart-account-address) (create a smart account client) ;

### Description

Context: 
```
1. The hash must be treated as userOp hashes for `eth_getTransactionReceipt`
2. The account nonce must be returned for `eth_getTransactionCount`
```

- feat(iframe): adapt `eth_getTransactionCount` and `eth_getTransactionReceipt` to support smart accounts 
- 
Added handling in permissionless requests `dispatchHandlers`  for `eth_getTransactionReceipt` and `eth_getTransactionCount` RPC methods to handle smart accounts.  

---

## Adapting `eth_getTransactionCount` for account abstraction

### The problem

With traditional EOA, `eth_getTransactionCount` returns a simple incrementing number that represents how many transactions an address has sent. However, account abstraction introduces a "2D nonce" system where instead of one sequence of transactions (0, 1, 2, 3...) :
- There are **multiple parallel sequences** identified by _"keys"_
- Each sequence can count up to 2⁶⁴-1 transactions
- The full nonce combines the key (upper 192 bits) and sequence number (lower 64 bits)

### Ok, but why do we need this ?

When apps call `eth_getTransactionCount`, they expect a simple incrementing number that represents the total number of transactions, that is used for calculating the next nonce and is compatible with existing tools and libraries.

**Smart account nonces are more complex** :
- Key 0's sequence: starts at `0x0` ;
- Key 1's sequence: starts at `0x10000000000000000` ;
- Key 2's sequence: starts at `0x20000000000000000` ;
etc.

### Solution

1. **Get the full nonce from the smart account** ;
2. Extract just the **sequence number** (lower 64 bits) ;
3. Return **only this number** to maintain compatibility ;

**This ensures apps get a simple incrementing number they can work with, while still allowing the smart account to use the full power of 2D nonces internally.**

## Adapting `eth_getTransactionReceipt` for account abstraction

### The problem
With traditional EOA, `eth_getTransactionReceipt` returns a receipt that shows exactly what your transaction did. However, with Account Abstraction, it is a bit different :
- User transactions become "**UserOperations**" (userOps) ;
- Multiple UserOperations get **bundled together** ;
- A **bundler** sends them all in one transaction ;
- **The default receipt shows the transaction of the bundler, _not your specific operation_**

### Ok, but why do we need this ?

When apps request a receipt, they expect to see :
- Where the transaction was sent (`to` field)
- Who sent it (`from` field)
- What data was sent (`data` field)
- If it succeeded (`status` field)

But instead, the receipt of the bundler shows :
- `to`: the `EntryPoint` contract
- `from`: the contract address of the bundler
- `data` : the bundled data for multiple operations
- `status` : Success/failure of _the entire bundle_ (not just your operation)

This makes it impossible for dapps to track what actually happened with their specific transaction.

### Solution

Reconstruct a meaningful receipt by :
1. Getting the UserOperation receipt ;
2. Finding the original UserOperation data ;
3. Decoding the actual transaction data from the UserOperation ;
4. Building a receipt that shows what the transaction of the user actually did ;

This ensures apps get useful information about their specific transaction, **not the transaction of the bundler**.

> **Why do we care about all of this ?**
>
> These modifications are crucial for account abstraction adoption because :
> 1. They maintain backwards compatibility with existing tooling
> 2. They hide the complexity of account abstraction from apps (and app builders)
> 3. They provide meaningful transaction data to devs, users and apps
> 4. They allow smart accounts to use advanced features (like parallel transactions) without breaking existing applications
>
> Without these adaptations, apps would :
> - Get incorrect transaction counts
> - See bundler transactions instead of user transactions
> - Have no way to track transaction status
> - Need to be completely rewritten to work with smart accounts

## Additional reads 

- [Quick overview of what User Operations are in ERC-4337 architecture](https://docs.stackup.sh/docs/erc-4337-overview#user-operations)
- [Guide on UserOperations nonce](https://docs.stackup.sh/docs/useroperation-nonce)

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

**Environment**
OS: Manjaro (6.2)
Browsers:
- (desktop) Firefox 131.0.3 
- (desktop) Chrome 128.0.6613.119

**Code flows**

1. `eth_getTransactionReceipt`: 
 - Gets `UserOperation` receipt from the bundler
 - Retrieves original `UserOperation` data to access sender and calldata
 - Decodes the execute calldata to get actual transaction details
 - Constructs a relevant receipt combining :
   - Expected Standard receipt fields (`blockHash`, `blockNumber`, etc.)
   - UserOp-specific fields (`from`, `to`, `data`)
   - Additional metadata (`userOpHash`, `success`, `actualGasUsed`)

2. `eth_getTransactionCount`:
 - For smart accounts:
   - Gets the full nonce
   - Extracts just the sequence number
   - Returns this number to maintain compatibility with existing tools

> Needs the other smart accounts tasks to be completed to check the whole user flow.

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
