### PR TITLE
Improve nonce initialization logic

### DIFF
--- a/packages/transaction-manager/lib/NonceManager.ts
+++ b/packages/transaction-manager/lib/NonceManager.ts
@@ -17,15 +17,15 @@ export class NonceManager {
             address: address,
         })
 
-        const highestNonce = this.txmgr.transactionRepository.getHighestNonce()
+        const highestDbNonce = this.txmgr.transactionRepository.getHighestNonce()
 
-        if (!highestNonce) {
+        if (!highestDbNonce || highestDbNonce < blockchainNonce) {
             this.nonce = blockchainNonce
             this.returnedNonceQueue = []
         } else {
-            this.nonce = highestNonce + 1
+            this.nonce = highestDbNonce + 1
             this.returnedNonceQueue = this.txmgr.transactionRepository
-                .getNotReservedNoncesInRange(blockchainNonce, highestNonce)
+                .getNotReservedNoncesInRange(blockchainNonce, highestDbNonce)
                 .sort((a, b) => a - b)
         }
     }


### PR DESCRIPTION
### Linked Issues

- closes  https://linear.app/happychain/issue/HAPPY-233/txmanager-if-the-blockchain-nonce-is-greater-than-repository-nonce-use

### Description

Improves nonce management logic by properly handling cases where the blockchain nonce is higher than the highest database nonce. 

This could happen if, for example, the account we are using in the TXM was used elsewhere while the TXM was turned off

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>