### PR TITLE
Refactor via-ir flag to only be used for Kernel.sol

### DIFF
--- a/packages/contracts/Makefile
+++ b/packages/contracts/Makefile
@@ -82,11 +82,11 @@ test-gas:
 .PHONY: test-gas
 
 gas-paymaster:
-	forge test -vv --match-contract GasEstimator --rpc-url $(RPC_LOCAL) --optimizer-runs 200 --isolate | awk '/^Logs:/{p=1; next} p && !/^Suite result:/ && !/^Ran [0-9]+ test suite/' | sed 's/^  //' | sed '/^$$/d' > paymaster_gas_report.txt
+	forge test -vv --match-contract GasEstimator --rpc-url $(RPC_LOCAL) --isolate | awk '/^Logs:/{p=1; next} p && !/^Suite result:/ && !/^Ran [0-9]+ test suite/' | sed 's/^  //' | sed '/^$$/d' > paymaster_gas_report.txt
 .PHONY: gas-paymaster
 
 test-aa-gas-flamechart:
-	forge test -vv --match-contract GasEstimator --rpc-url $(RPC_LOCAL) --optimizer-runs 200 --isolate --flamechart
+	forge test -vv --match-contract GasEstimator --rpc-url $(RPC_LOCAL) --isolate --flamechart
 .PHONY: test-aa-gas-flamechart
 
 test-fork:
@@ -139,8 +139,6 @@ VERIFY_FLAG := $(if $(findstring true,$(VERIFY_$(CONFIG))),--verify,)
 VERIFIER_FLAG := $(if $(findstring true,$(VERIFY_$(CONFIG))),$(VERIFIER_FLAG_$(CONFIG)),)
 VERIFIER_URL := $(if $(findstring true,$(VERIFY_$(CONFIG))),$(VERIFIER_URL_$(CONFIG)),)
 CHECK_UPGRADE := make validate-upgrade
-# VIA_IR_FLAG := $(if $(findstring DeployAA,$(DEPLOY_SCRIPT)),--via-ir,)
-# OPTIMIZER_RUNS_FLAG := $(if $(findstring DeployAA,$(DEPLOY_SCRIPT)),--optimizer-runs 200,)
 
 ifeq ($(DEPLOY),deploy)
 	BROADCAST_FLAG := --broadcast
@@ -186,8 +184,6 @@ define run-deploy-script-key
 	forge script $(1) \
 		--fork-url $(RPC_$(CONFIG)) \
 		--private-key $(PRIVATE_KEY_$(CONFIG)) \
-		# $(VIA_IR_FLAG) \
-		# $(OPTIMIZER_RUNS_FLAG) \
 		$(BROADCAST_FLAG) \
 		$(VERIFY_FLAG) \
 		$(VERIFIER_FLAG) \
@@ -206,8 +202,6 @@ define run-deploy-script-account
 		--account $(ACCOUNT_$(CONFIG)) \
 		--password-file $(PASSFILE_$(CONFIG)) \
 		--sender $(DEPLOY_SENDER) \
-		# $(VIA_IR_FLAG) \
-		# $(OPTIMIZER_RUNS_FLAG) \
 		$(BROADCAST_FLAG) \
 		$(VERIFY_FLAG) \
 		$(VERIFIER_FLAG) \

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -8,12 +8,12 @@ optimizer = true
 optimizer_runs = 20000
 via_ir = false
 
-# Compiler profile for kernel contract
+# Compiler profile for the Kernel contract
 additional_compiler_profiles = [
   { name = "kernel", via_ir = true, optimizer = true, optimizer_runs = 200 }
 ]
 
-# Restrict kernel.sol to use the kernel profile
+# Restrict Kernel.sol to use the Kernel profile
 compilation_restrictions = [
   { paths = "lib/kernel/src/Kernel.sol", via_ir = true, optimizer = true, optimizer_runs = 200 }
 ]


### PR DESCRIPTION
### Linked Issues
NOISSUE

### Description

`forge build` time dropped from ~35 seconds to ~22 seconds.

[Inspiration](https://x.com/gretzke/status/1861175176005570977) for this update in the `foundry.toml`, which allows for selective compiler configurations. This was referenced by @norswap on Slack.

We use this to restrict the `--via-ir` flag to ONLY the imported `Kernel.sol` contract.

Next step could be to try to switch to solc version `0.8.28` as @aodhgan suggested in standup meeting, it's nearly 3x faster than previous versions, when compiling with `--via-ir`, but it's the latest solc version currently, so we might want to wait before switching to it.

[Original PR](https://github.com/foundry-rs/foundry/pull/8668) in Foundry repo which implemented this feature (couldn't find proper documentation in the Foundry book yet, so this is our reference source).  

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
