### PR TITLE
connection-modal-overflow

### DIFF
--- a/packages/iframe/src/components/ConnectModal.tsx
+++ b/packages/iframe/src/components/ConnectModal.tsx
@@ -62,14 +62,14 @@ export function ConnectModal() {
 
     return (
         <>
-            <main className="h-dvh w-screen rounded-3xl px-16 py-8 flex flex-col justify-center gap-8">
-                <div className="flex items-center justify-center">
+            <main className="h-dvh w-screen rounded-3xl px-16 py-8 flex flex-col justify-around">
+                <div className="flex min-h-1/4 items-center justify-center">
                     <div className="flex flex-col items-center gap-4">
                         <img alt="HappyChain Logo" src={happychainLogo} className="mx-auto size-24 drop-shadow-lg" />
                         <p className="text-2xl font-bold">HappyChain</p>
                     </div>
                 </div>
-                <div className="flex flex-col gap-4 max-w-md mx-auto w-full">
+                <div className="flex flex-col gap-4 max-h-3/4 w-full overflow-auto">
                     {providers.map((prov) => {
                         return (
                             <Button


### PR DESCRIPTION
### Linked Issues

- closes HAPPY-240

### Description

When multiple EIP6963 providers exist, and they overflow the connection screen
the resulting default scrollwheel expose the red (disconnected) background.

This PR adds a basic overflow scroll and max height when needed.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

Tested on Chrome with Rabby,Metamask,Phantom,Google. (I also have Kepler installed, but for some reason its not exposing itself via 6963 events). To ensure I had enough providers to 
cause the overflow, I concatenated the same provider multiple times.

- [x] C4. I have performed a thorough self-review of my code after submitting the PR, and have updated the code & comments accordingly. 

### Architecture & Documentation 

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries, (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
