### PR TITLE
bigint-serialization-error

### DIFF
--- a/packages/iframe/src/components/JotaiDevTools.tsx
+++ b/packages/iframe/src/components/JotaiDevTools.tsx
@@ -1,4 +1,4 @@
-import { DevTools, useAtomsDebugValue, useAtomsDevtools } from "jotai-devtools"
+import { DevTools, useAtomsDebugValue } from "jotai-devtools"
 
 import "jotai-devtools/styles.css"
 
@@ -8,9 +8,6 @@ export function JotaiDevTools() {
     // (By default in Next, the atoms are listed but they don't have their proper names.)
     // Note that the naming here relies on atoms having their `debugLabel` properties set.
     useAtomsDebugValue()
-    // Enables tracking atom value changes in the Redux dev tool, as well as time travelling, etc
-    // The Redux dev tool needs to be open and a state change to happen for it to display anything.
-    useAtomsDevtools("atomDevtools")
 
     return <DevTools position="bottom-right" />
 }


### PR DESCRIPTION
### Linked Issues

- closes HAPPY-209

### Description

Redux detools fail to use custom serialization/deserialization for jotai atoms
resulting in errors when devtools are enabled. This removes redux integration which
is the source of the issue, so we can no longer use redux time-travel, however, the 
page no longer crashes.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

Direct access the iframe with redux devtools installed and enabled. Send yourself some $HAPPY and see if the page crashes. Before this PR it will crash when you view your transaction history. After this PR it works fine. Note: devtools are only enabled during
direct access, so if viewed through a demo app, there is no issue, similarly, if redux devtools are not installed, there is no issue.

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
