### PR TITLE
connect-feedback

### DIFF
--- a/packages/iframe/src/components/ConnectModal.tsx
+++ b/packages/iframe/src/components/ConnectModal.tsx
@@ -1,12 +1,12 @@
 import { createUUID } from "@happychain/common"
 import { type ConnectionProvider, Msgs, type MsgsFromApp, WalletDisplayAction } from "@happychain/sdk-shared"
 import { useMutation } from "@tanstack/react-query"
-import { cx } from "class-variance-authority"
 import { useEffect, useState } from "react"
 import { iframeID } from "#src/requests/utils.ts"
 import happychainLogo from "../assets/happychain.png"
 import { useConnectionProviders } from "../connections/initialize"
 import { appMessageBus } from "../services/eventBus"
+import { DotLinearMotionBlurLoader } from "./loaders/DotLinearMotionBlurLoader"
 import { Button } from "./primitives/button/Button"
 
 export function ConnectModal() {
@@ -69,30 +69,38 @@ export function ConnectModal() {
                         <p className="text-2xl font-bold">HappyChain</p>
                     </div>
                 </div>
-                <div className="flex flex-col gap-4 max-h-3/4 w-full overflow-auto">
-                    {providers.map((prov) => {
-                        return (
-                            <Button
-                                intent="secondary"
-                                type="button"
-                                key={prov.id}
-                                onClick={() => mutationLogin.mutate(prov)}
-                            >
-                                <img
-                                    className={cx(
-                                        "h-full w-auto max-w-8",
-                                        mutationLogin.isPending &&
-                                            mutationLogin.variables?.id !== prov.id &&
-                                            "grayscale",
-                                    )}
-                                    src={prov.icon}
-                                    alt={`${prov.name} icon`}
-                                />
-                                <span className="grow me-8">{prov.name}</span>
-                            </Button>
-                        )
-                    })}
-                </div>
+                {mutationLogin.isPending ? (
+                    <div className="grid gap-8">
+                        <div className="flex items-center justify-center gap-4">
+                            <img alt="HappyChain Logo" src={happychainLogo} className="h-12" />
+                            <DotLinearMotionBlurLoader />
+                            <img
+                                className="h-8"
+                                src={mutationLogin.variables?.icon}
+                                alt={`${mutationLogin.variables?.name} icon`}
+                            />
+                        </div>
+                        <div className="text-center flex items-center justify-center">
+                            Verify your {mutationLogin.variables?.name} account to continue with HappyChain.
+                        </div>
+                    </div>
+                ) : (
+                    <div className="flex flex-col gap-4 max-h-3/4 w-full overflow-auto">
+                        {providers.map((prov) => {
+                            return (
+                                <Button
+                                    intent="secondary"
+                                    type="button"
+                                    key={prov.id}
+                                    onClick={() => mutationLogin.mutate(prov)}
+                                >
+                                    <img className="h-full w-auto max-w-8" src={prov.icon} alt={`${prov.name} icon`} />
+                                    <span className="grow me-8">{prov.name}</span>
+                                </Button>
+                            )
+                        })}
+                    </div>
+                )}
             </main>
         </>
     )

--- a/packages/iframe/src/components/loaders/DotLinearWaveLoader.tsx
+++ b/packages/iframe/src/components/loaders/DotLinearWaveLoader.tsx
@@ -1,16 +1,14 @@
 export function DotLinearWaveLoader() {
     return (
-        <div className="flex h-dvh w-full items-center justify-center">
-            <div className="loadership_JYJXM">
-                <div />
-                <div />
-                <div />
-                <div />
-                <div />
-                <div />
-                <div />
-                <div />
-            </div>
+        <div className="loadership_JYJXM">
+            <div />
+            <div />
+            <div />
+            <div />
+            <div />
+            <div />
+            <div />
+            <div />
         </div>
     )
 }

--- a/packages/iframe/src/routes/request.lazy.tsx
+++ b/packages/iframe/src/routes/request.lazy.tsx
@@ -45,7 +45,11 @@ function Request() {
     }
 
     if (isLoading) {
-        return <DotLinearWaveLoader />
+        return (
+            <div className="flex h-dvh w-full items-center justify-center">
+                <DotLinearWaveLoader />
+            </div>
+        )
     }
 
     switch (req.method as keyof typeof requestLabels) {


### PR DESCRIPTION
### Linked Issues

- closes HAPPY-223

### Description

When Connecting there should be feedback to let the user know the connecting is in fact in progress. This was difficult to implement nicely before due to firebase 8 second timeout
for failed attempts, however this has been worked around now. This PR adds a little connecting animation.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

  Connect to a demo, and log in with any method. Login process should nicely indicated which and failure and cancels revert to the original view, where success logs the user in.

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>

https://github.com/user-attachments/assets/5de27df2-7e12-47e7-8857-1b8d9383c4f6

