### PR TITLE
fix: account for value being undefined in request handler

### DIFF
--- a/packages/iframe/src/requests/approved.ts
+++ b/packages/iframe/src/requests/approved.ts
@@ -43,12 +43,7 @@ export async function dispatchHandlers(request: PopupMsgs[Msgs.PopupApprove]) {
 
             const hash = (await sendToWalletClient(request)) as Hash
 
-            let value: bigint
-            if (request.payload.params[0].value) {
-                value = hexToBigInt(request.payload.params[0].value as Hex)
-            } else {
-                value = 0n
-            }
+            const value = request.payload.params[0].value ? hexToBigInt(request.payload.params[0].value as Hex) : 0n
 
             const payload: PendingTxDetails = { hash, value }
             addPendingTx(user.address, payload)


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-251/extend-eth-sendtransaction-handler-to-account-for-contract-writes-with

### Description

Handles `value` field in the payload for `eth_sendTransaction` being undefined.  

-- [example](https://viem.sh/docs/contract/writeContract.html#passing-arguments)

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
