### PR TITLE
Notify user if txm fails saving transactions

### DIFF
--- a/packages/transaction-manager/lib/EventBus.ts
+++ b/packages/transaction-manager/lib/EventBus.ts
@@ -3,6 +3,7 @@ import EventEmitter from "eventemitter3"
 export enum Topics {
     NewBlock = "NewBlock",
     TransactionStatusChanged = "TransactionStatusChanged",
+    TransactionSaveFailed = "TransactionSaveFailed",
 }
 
 export type EventBus = EventEmitter<Topics>

--- a/packages/transaction-manager/lib/HookManager.ts
+++ b/packages/transaction-manager/lib/HookManager.ts
@@ -4,6 +4,7 @@ import type { Transaction } from "./Transaction.js"
 export enum TxmHookType {
     All = "All",
     TransactionStatusChanged = "TransactionStatusChanged",
+    TransactionSaveFailed = "TransactionSaveFailed",
 }
 
 export type TxmHookPayload = {
@@ -30,8 +31,10 @@ export class HookManager {
         this.hooks = {
             [TxmHookType.All]: [],
             [TxmHookType.TransactionStatusChanged]: [],
+            [TxmHookType.TransactionSaveFailed]: [],
         }
         eventBus.on(Topics.TransactionStatusChanged, this.onTransactionStatusChanged.bind(this))
+        eventBus.on(Topics.TransactionSaveFailed, this.onTransactionSaveFailed.bind(this))
     }
 
     public async addHook(handler: TxmHookHandler, type: TxmHookType): Promise<void> {
@@ -47,6 +50,17 @@ export class HookManager {
         this.hooks[TxmHookType.TransactionStatusChanged].concat(this.hooks[TxmHookType.All]).map((h) =>
             h({
                 type: TxmHookType.TransactionStatusChanged,
+                transaction: payload.transaction,
+            }),
+        )
+    }
+
+    private async onTransactionSaveFailed(payload: {
+        transaction: Transaction
+    }): Promise<void> {
+        this.hooks[TxmHookType.TransactionSaveFailed].concat(this.hooks[TxmHookType.All]).map((h) =>
+            h({
+                type: TxmHookType.TransactionSaveFailed,
                 transaction: payload.transaction,
             }),
         )

--- a/packages/transaction-manager/lib/TransactionCollector.ts
+++ b/packages/transaction-manager/lib/TransactionCollector.ts
@@ -28,9 +28,12 @@ export class TransactionCollector {
 
         const saveResult = await this.txmgr.transactionRepository.saveTransactions(transactionsBatch)
 
-        // TODO: If flush fails, we should notify the user
         if (saveResult.isErr()) {
-            throw saveResult.error
+            for (const transaction of transactionsBatch) {
+                eventBus.emit(Topics.TransactionSaveFailed, { transaction })
+            }
+            console.error("Error saving transactions", saveResult.error)
+            return
         }
 
         await Promise.all(

--- a/packages/transaction-manager/lib/TransactionRepository.ts
+++ b/packages/transaction-manager/lib/TransactionRepository.ts
@@ -1,6 +1,6 @@
 import { unknownToError } from "@happychain/common"
 import type { UUID } from "@happychain/common"
-import { type Result, ResultAsync } from "neverthrow"
+import { type Result, ResultAsync, err } from "neverthrow"
 import { Topics, eventBus } from "./EventBus.js"
 import { NotFinalizedStatuses, Transaction } from "./Transaction.js"
 import type { TransactionManager } from "./TransactionManager.js"


### PR DESCRIPTION
### Linked issues

closes https://linear.app/happychain/issue/HAPPY-249/notify-user-if-txm-fails-saving-a-transaction

### Description

Added support for transaction save failure notifications through a new hook type. When transactions fail to save, the system now emits a `TransactionSaveFailed` hook instead of throwing an error. This enables better error handling and allows consumers to react to save failures through hooks.

Key changes:
- Implemented new hook type for transaction save failures
- Modified `TransactionCollector` to emit events instead of throwing errors

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments.
- [x] C3. I have manually tested my changes & connected features.

- [x] C4. I have performed a thorough self-review of my code after submitting the PR.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code.
- [x] D2. All public-facing APIs & meaningful internal APIs are properly documented.
- [x] D3. If appropriate, the general architecture is documented.

</details>