### PR TITLE
remove worker log statement

### DIFF
--- a/packages/worker/src/runtime/server.ts
+++ b/packages/worker/src/runtime/server.ts
@@ -100,14 +100,12 @@ export class SharedWorkerServer implements ServerInterface {
         // Shared workers unsupported, start as web worker
         if (!("SharedWorkerGlobalScope" in self)) {
             this.start(self as unknown as MessagePort)
-            console.log("Started as WebWorker")
             return
         }
 
         this._scope.onconnect = (event) => {
             const port = event.ports[0]
             this.start(port)
-            console.log(`Started as SharedWorker. Client #${this._ports.size}`)
         }
     }
 


### PR DESCRIPTION
### Description

@not-reed just deleting these logs as they are the only thing that shows up in the console all the time, and they're easy to get rid of.

I thought of introducing the "tagged logger" abstraction I was thinking about, but the simplest version of it requires a global `window` variable to set tags, and the shared worker doesn't share the global `windows`. We could define tags as environment variables though, and maybe we should.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
