### PR TITLE
Add NewBlock hook

### DIFF
--- a/packages/txm/lib/TransactionManager.ts
+++ b/packages/txm/lib/TransactionManager.ts
@@ -264,8 +264,8 @@ export class TransactionManager {
      * @param type - The type of hook to add.
      * @param handler - The handler function to add.
      */
-    public async addHook<T extends TxmHookType>(handler: TxmHookHandler<T>, type: T): Promise<void> {
-        await this.hookManager.addHook(handler, type)
+    public async addHook<T extends TxmHookType>(type: T, handler: TxmHookHandler<T>): Promise<void> {
+        await this.hookManager.addHook(type, handler)
     }
 
     public async getTransaction(txIntentId: UUID): Promise<Transaction | undefined> {


### PR DESCRIPTION
### Linked Issues
- closes https://linear.app/happychain/issue/HAPPY-257/create-onnewblock-hook

### Description

Adds a new block hook to the transaction manager and moves `pruning` and `reveal not submitted` logic to be triggered by new blocks instead of by transaction collector. This improves the separation of concerns by having these operations respond to time-based triggers rather than transaction events.

Key changes:
- Added `NewBlock` hook type to transaction manager
- Enhanced type safety for hook handlers using TypeScript generics
- Moved `pruning` logic and `reveal not submitted`  from transaction collector to new block handler
- Added proper hook registration for new block events

### Checklist

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>