### PR TITLE
Only prune finalized randomness entries

### DIFF
--- a/apps/randomness/src/Randomness.ts
+++ b/apps/randomness/src/Randomness.ts
@@ -13,6 +13,12 @@ export enum RandomnessStatus {
     REVEAL_NOT_SUBMITTED_ON_TIME = "REVEAL_NOT_SUBMITTED_ON_TIME",
 }
 
+export const FINALIZED_STATUSES = [
+    RandomnessStatus.REVEAL_EXECUTED,
+    RandomnessStatus.REVEAL_FAILED,
+    RandomnessStatus.REVEAL_NOT_SUBMITTED_ON_TIME,
+]
+
 export class Randomness {
     public timestamp: bigint
     public value: bigint

--- a/apps/randomness/src/RandomnessRepository.ts
+++ b/apps/randomness/src/RandomnessRepository.ts
@@ -1,7 +1,7 @@
 import { type UUID, unknownToError } from "@happy.tech/common"
 import { bigIntToZeroPadded } from "@happy.tech/common"
 import { type Result, ResultAsync } from "neverthrow"
-import type { Randomness, RandomnessStatus } from "./Randomness"
+import { FINALIZED_STATUSES, type Randomness, type RandomnessStatus } from "./Randomness"
 import { db } from "./db/driver"
 import { randomnessEntityToRow, randomnessRowToEntity } from "./db/types"
 
@@ -87,6 +87,7 @@ export class RandomnessRepository {
                     "<",
                     bigIntToZeroPadded(latestBlockTimestamp - COMMITMENT_PRUNE_INTERVAL_SECONDS, DIGITS_MAX_UINT256),
                 )
+                .where("status", "in", FINALIZED_STATUSES)
                 .execute(),
             unknownToError,
         ).map(() => undefined)


### PR DESCRIPTION
### Linked Issues
- closes https://linear.app/happychain/issue/HAPPY-258/purge-only-finalized-randomnness

### Description

Added a new constant `FINALIZED_STATUSES` to track completed randomness states and modified the pruning logic to only remove entries that have reached a final status. This prevents premature deletion of active randomness entries.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>