### PR TITLE
fix-safari-drag

### DIFF
--- a/packages/sdk-vanillajs/lib/wallet/hooks/useWalletDragger.ts
+++ b/packages/sdk-vanillajs/lib/wallet/hooks/useWalletDragger.ts
@@ -1,6 +1,6 @@
 import { throttle } from "@happychain/common"
 import { useEffect, useRef, useState } from "preact/hooks"
-import { isFirefox, makeBlankImage } from "../utils"
+import { isChrome, makeBlankImage } from "../utils"
 
 const blank = makeBlankImage()
 
@@ -225,8 +225,10 @@ function useCustomDrag({ enabled }: { enabled: boolean }) {
 }
 
 export function useWalletDragger() {
-    const nativeDrag = useNativeDrag({ enabled: !isFirefox })
-    const customDrag = useCustomDrag({ enabled: isFirefox })
+    const nativeDragEnabled = isChrome
 
-    return isFirefox ? customDrag : nativeDrag
+    const nativeDrag = useNativeDrag({ enabled: nativeDragEnabled })
+    const customDrag = useCustomDrag({ enabled: !nativeDragEnabled })
+
+    return nativeDragEnabled ? nativeDrag : customDrag
 }

--- a/packages/sdk-vanillajs/lib/wallet/utils.ts
+++ b/packages/sdk-vanillajs/lib/wallet/utils.ts
@@ -26,4 +26,10 @@ export function makeBlankImage() {
     return img
 }
 
+/**
+ * Feature Detection would be much better, however not possible in this case. The primary use here
+ * is for the drag-and-drop API, which is baseline/'fully supported' on all modern browsers, however
+ * the implementation for many (such as Firefox and Safari) is broken in reality.
+ */
 export const isFirefox = navigator.userAgent.includes("Firefox")
+export const isChrome = navigator.userAgent.includes("Chrome")


### PR DESCRIPTION
### Linked Issues

- closes HAPPY-269

### Description

Safari is using the native drag-and-drop api, same as Chrome, however browser implementation is broken,
similar to firefox. This changes the default from 'native dragging' with the exception being firefox
using a custom implementation, to the default being the custom implementation, with the exception being
chrome (and chrome based) browsers using the native implementation.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

  - MacOS Safari
  - Linux Chrome, Firefox, LibreWolf, Opera, Vivaldi, Brave

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
