### PR TITLE
fix: make nuke recipe ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,10 @@ clean: ts.clean docs.clean contracts.clean ## Removes build artifacts
 build: node_modules ts.build  ## Creates production builds
 .PHONY: build
 
-nuke: remove-modules clean ## Removes build artifacts and dependencies
+nuke: clean ## Removes build artifacts and dependencies 
 	cd packages/contracts && make nuke
 	cd packages/bundler && make nuke
+	$(MAKE) remove-modules
 .PHONY: nuke
 
 test: sdk.test iframe.test ## Run tests


### PR DESCRIPTION
### Description

running `make nuke` is currently broken because `forge clean` run as part of `make clean` in `packages/contracts` apparently needs some contracts from open zeppelin to be present. moving the ordering of deletion of node_modules to **after** fixes this. 

old `make nuke` error:

```
Removing all node_modules
Running make clean in packages/common
Running make clean in packages/sdk-shared
Running make clean in packages/sdk-vanillajs
Running make clean in packages/sdk-react
Running make clean in packages/sdk-frontend-components
Running make clean in packages/worker
Running make clean in packages/iframe
Running make clean in packages/demo-vanillajs
Running make clean in packages/demo-react
Running make clean in packages/demo-wagmi-vue
Running make clean in packages/common
Running make clean in packages/transaction-manager
Running make clean in packages/randomness-service
2024-12-20T21:53:33.221801Z ERROR foundry_compilers_artifacts_solc::sources: error="/Users/aodhgan/happychain-clone/packages/contracts/lib/openzeppelin/src/token/ERC20/extensions/ERC20Permit.sol": No such file or directory (os error 2)
Error: failed to resolve file: "/Users/aodhgan/happychain-clone/packages/contracts/lib/openzeppelin/src/token/ERC20/extensions/ERC20Permit.sol": No such file or directory (os error 2); check configured remappings
        --> /Users/aodhgan/happychain-clone/packages/contracts/src/HappyERC20.sol
        openzeppelin/token/ERC20/extensions/ERC20Permit.sol
make[1]: *** [clean] Error 1
make: *** [contracts.clean] Error 2
```