### PR TITLE
faster-user-display

### DIFF
--- a/packages/common/lib/debug/Tracer.ts
+++ b/packages/common/lib/debug/Tracer.ts
@@ -1,0 +1,32 @@
+export class Tracer {
+    events: PerformanceMark[] = []
+    track(name: string, options: PerformanceMarkOptions["detail"]) {
+        const time = performance.mark(name, { detail: options })
+        this.events.push(time)
+    }
+    clear() {
+        this.events = []
+    }
+    results() {
+        // the should be sorted, but may not be. cache snapshot locally.
+        const sortedEvents = [...this.events].sort((a, b) => a.startTime - b.startTime)
+
+        const table = []
+        for (let i = 0; i < sortedEvents.length - 1; i++) {
+            table.push(this.formatRow(sortedEvents[i], sortedEvents[i + 1]))
+        }
+        console.table(table)
+
+        // show total
+        console.log(
+            performance.measure("tracer-results", sortedEvents[0].name, sortedEvents[sortedEvents.length - 1].name),
+        )
+    }
+
+    formatRow(start: PerformanceMark, end: PerformanceMark) {
+        const m = performance.measure("tracer-results", start.name, end.name)
+        return { Start: start.name, End: end.name, "Duration (ms)": m.duration }
+    }
+}
+
+export const tracer = new Tracer()

--- a/packages/common/lib/debug/index.ts
+++ b/packages/common/lib/debug/index.ts
@@ -1,0 +1,1 @@
+export * from "./Tracer"

--- a/packages/iframe/src/connections/GoogleConnector.ts
+++ b/packages/iframe/src/connections/GoogleConnector.ts
@@ -1,5 +1,5 @@
 import { type HappyUser, WalletType } from "@happychain/sdk-shared"
-import { connect, disconnect } from "@wagmi/core"
+import { connect as connectWagmi, disconnect as disconnectWagmi } from "@wagmi/core"
 import { type AuthProvider, GoogleAuthProvider } from "firebase/auth"
 import type { EIP1193Provider } from "viem"
 import { setUserWithProvider } from "#src/actions/setUserWithProvider.ts"
@@ -62,13 +62,13 @@ export class GoogleConnector extends FirebaseConnector {
          * to repeat on the next page refresh.
          */
         if (storage.get(StorageKey.HappyUser)?.type !== WalletType.Social) return
-        await disconnect(config)
+        await disconnectWagmi(config)
         setUserWithProvider(undefined, undefined)
     }
 
     async onReconnect(user: HappyUser, provider: EIP1193Provider) {
         setUserWithProvider(user, provider)
-        await connect(config, { connector: happyConnector })
+        await connectWagmi(config, { connector: happyConnector })
     }
 
     async onConnect(user: HappyUser, provider: EIP1193Provider) {
@@ -81,6 +81,6 @@ export class GoogleConnector extends FirebaseConnector {
         }
         setUserWithProvider(user, provider)
         grantPermissions(getAppURL(), "eth_accounts")
-        await connect(config, { connector: happyConnector })
+        await connectWagmi(config, { connector: happyConnector })
     }
 }

--- a/packages/iframe/src/listeners/atoms.ts
+++ b/packages/iframe/src/listeners/atoms.ts
@@ -51,6 +51,12 @@ store.sub(userAtom, () => {
 })
 
 /**
+ * If a user exists in the atom at page load, lets emit this to the front end immediately
+ * while the web3 components get wired up
+ */
+if (store.get(userAtom)) emitUserUpdate(store.get(userAtom))
+
+/**
  * Emits user updates to the app if permitted and needed.
  *
  * @listens permissionsMapAtom

--- a/packages/iframe/src/routes/embed.lazy.tsx
+++ b/packages/iframe/src/routes/embed.lazy.tsx
@@ -1,9 +1,8 @@
-import { AuthState, WalletDisplayAction, waitForCondition } from "@happychain/sdk-shared"
+import { WalletDisplayAction } from "@happychain/sdk-shared"
 import { Msgs } from "@happychain/sdk-shared"
 import { Outlet, createLazyFileRoute, useLocation, useNavigate } from "@tanstack/react-router"
 import { useAtomValue } from "jotai"
 import { useEffect } from "react"
-import { getAuthState } from "#src/state/authState.ts"
 import { signalClosed, signalOpen } from "#src/utils/walletState.ts"
 import { ConnectModal } from "../components/ConnectModal"
 import GlobalHeader from "../components/interface/GlobalHeader"
@@ -29,7 +28,6 @@ function Embed() {
 
     useEffect(() => {
         const unsubscribe = appMessageBus.on(Msgs.RequestWalletDisplay, async (screen) => {
-            await waitForCondition(() => getAuthState() !== AuthState.Initializing)
             switch (screen) {
                 case WalletDisplayAction.Home:
                     void navigate({ to: "/embed" })

--- a/packages/iframe/src/state/user.ts
+++ b/packages/iframe/src/state/user.ts
@@ -6,7 +6,7 @@ import { getAddress } from "viem"
 import { StorageKey, storage } from "../services/storage.ts"
 
 const userCompare = (a: HappyUser | undefined, b: HappyUser | undefined) => a?.uid === b?.uid
-const initialUserValue = undefined
+const initialUserValue = storage.get(StorageKey.HappyUser)
 
 // Base atom for the user, wrapped by `userAtom` to provide a custom setter.
 const baseUserAtom = atomWithCompare<HappyUser | undefined>(initialUserValue, userCompare)

--- a/packages/sdk-vanillajs/lib/wallet/WalletFrame.tsx
+++ b/packages/sdk-vanillajs/lib/wallet/WalletFrame.tsx
@@ -35,7 +35,6 @@ export const WalletFrame = ({ dragging }: WalletFrameProps) => {
         >
             {/* Base64 to avoid any bundle issues and network requests */}
             <img src={icon64x64} alt="HappyChain Logo" className="wallet-logo" inert={true} />
-
             <div className="wallet-iframe-wrapper" inert={!isOpen}>
                 <span ref={iframe}>
                     <slot name="frame" />

--- a/packages/sdk-vanillajs/lib/wallet/styles.css
+++ b/packages/sdk-vanillajs/lib/wallet/styles.css
@@ -139,10 +139,6 @@
         transition-duration: 0;
     }
 
-    &[data-auth-state="initializing"] {
-        background-color: rgb(252 211 77 / 1);
-    }
-
     &[data-auth-state="authenticated"] {
         background-color: rgb(14 165 233 / 1);
     }


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes <linear issue URL>

### Description

Now on re-connect/refresh etc, if a user is found in localStorage, its presented right away,
instead of waiting for firebase/web3auth to connect.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.
- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
