### PR TITLE
Add configurable HTTP polling interval for block monitoring

### DIFF
--- a/packages/txm/lib/BlockMonitor.ts
+++ b/packages/txm/lib/BlockMonitor.ts
@@ -22,9 +22,7 @@ export class BlockMonitor {
             onBlock: this.onNewBlock.bind(this),
             ...(this.txmgr.transportProtocol === "http"
                 ? {
-                      pollingInterval: Math.floor(
-                          (Number(this.txmgr.blockTime) * 1000) / this.txmgr.pollingIntervalFraction,
-                      ),
+                      pollingInterval: this.txmgr.pollingInterval,
                   }
                 : {}),
         })

--- a/packages/txm/lib/TransactionManager.ts
+++ b/packages/txm/lib/TransactionManager.ts
@@ -65,11 +65,10 @@ export type TransactionManagerConfig = {
         allowDebug?: boolean
 
         /**
-         * Specifies the fraction of the block time to be used as the polling interval.
-         * This setting is applicable only when the RPC protocol is HTTP.
-         * By default, the polling interval is set to 1/8 of the block time, meaning the system will poll every 1/8th of the block time.
+         * Specifies the polling interval in milliseconds.
+         * Defaults to 1/2 of the block time.
          */
-        pollingIntervalFraction?: number
+        pollingInterval?: number
     }
     /** The private key of the account used for signing transactions. */
     privateKey: Hex
@@ -166,7 +165,7 @@ export class TransactionManager {
     public readonly rpcAllowDebug: boolean
     public readonly blockTime: bigint
     public readonly finalizedTransactionPurgeTime: number
-    public readonly pollingIntervalFraction: number
+    public readonly pollingInterval: number
     public readonly transportProtocol: "http" | "websocket"
 
     public started: boolean
@@ -261,7 +260,7 @@ export class TransactionManager {
         this.blockTime = _config.blockTime || 2n
         this.finalizedTransactionPurgeTime = _config.finalizedTransactionPurgeTime || 2 * 60 * 1000
 
-        this.pollingIntervalFraction = _config.rpc.pollingIntervalFraction || 8
+        this.pollingInterval = _config.rpc.pollingInterval || (Number(this.blockTime) * 1000) / 2
 
         this.started = false
     }


### PR DESCRIPTION
### Linked Issues
- closes https://linear.app/happychain/issue/HAPPY-303/if-the-rpc-provider-is-http-configure-the-polling-interval-to-avoid
 
### Description

Adds configurable HTTP polling interval for block monitoring based on block time. When using HTTP transport, the system now polls for new blocks at an interval that is a fraction of the block time (defaulting to 1/8th)


<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>