### PR TITLE
Increase default RPC timeout to 2000ms

### DIFF
--- a/packages/txm/lib/TransactionManager.ts
+++ b/packages/txm/lib/TransactionManager.ts
@@ -43,7 +43,7 @@ export type TransactionManagerConfig = {
         url: string
         /**
          * The timeout for the RPC node.
-         * Defaults to 500 milliseconds.
+         * Defaults to 2000 milliseconds.
          */
         timeout?: number
         /**
@@ -181,7 +181,7 @@ export class TransactionManager {
 
         const retries = _config.rpc.retries || 2
         const retryDelay = _config.rpc.retryDelay || 50
-        const timeout = _config.rpc.timeout || 500
+        const timeout = _config.rpc.timeout || 2000
 
         let transport: ViemTransport
         if (this.transportProtocol === "http") {


### PR DESCRIPTION
### Linked Issues
- closes https://linear.app/happychain/issue/HAPPY-308/increase-the-default-timeout-to-allow-the-gas-estimator-to-spend-more
 
### Description

The default timeout is now 500ms, which is too low if you need to simulate a transaction to measure the gas limit

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>