### PR TITLE
fix(iframe): HAPPY-193 - Hide secondary actions menu when wallet  is closed/user disconnects

### DIFF
--- a/apps/iframe/src/routes/embed.lazy.tsx
+++ b/apps/iframe/src/routes/embed.lazy.tsx
@@ -1,9 +1,13 @@
 import { WalletDisplayAction } from "@happy.tech/wallet-common"
 import { Msgs } from "@happy.tech/wallet-common"
 import { Outlet, createLazyFileRoute, useLocation, useNavigate } from "@tanstack/react-router"
-import { useAtomValue } from "jotai"
+import { useAtom, useAtomValue } from "jotai"
 import { useEffect } from "react"
-import { signalClosed, signalOpen } from "#src/utils/walletState.ts"
+import {
+    dialogLogOutConfirmationVisibilityAtom,
+    secondaryMenuVisibilityAtom,
+} from "#src/components/interface/menu-secondary-actions/state"
+import { signalClosed, signalOpen } from "#src/utils/walletState"
 import { ConnectModal } from "../components/ConnectModal"
 import GlobalHeader from "../components/interface/GlobalHeader"
 import UserInfo from "../components/interface/UserInfo"
@@ -25,6 +29,8 @@ function Embed() {
     const user = useAtomValue(userAtom)
     const activeProvider = useActiveConnectionProvider()
     const navigate = useNavigate()
+    const [, setSecondaryMenuVisibility] = useAtom(secondaryMenuVisibilityAtom)
+    const [, setDialogLogoutVisibility] = useAtom(dialogLogOutConfirmationVisibilityAtom)
 
     useEffect(() => {
         const unsubscribe = appMessageBus.on(Msgs.RequestWalletDisplay, async (screen) => {
@@ -42,6 +48,8 @@ function Embed() {
                     break
                 case WalletDisplayAction.Closed:
                     signalClosed()
+                    setSecondaryMenuVisibility(false)
+                    setDialogLogoutVisibility(false)
                     break
             }
         })
@@ -50,9 +58,11 @@ function Embed() {
         // calls will be silently lost
         void appMessageBus.emit(Msgs.IframeInit, true)
         return unsubscribe
-    }, [navigate])
+    }, [navigate, setSecondaryMenuVisibility, setDialogLogoutVisibility])
 
     async function logout() {
+        setSecondaryMenuVisibility(false)
+        setDialogLogoutVisibility(false)
         void appMessageBus.emit(Msgs.WalletVisibility, { isOpen: false })
         await activeProvider?.disconnect()
     }


### PR DESCRIPTION
### Linked Issues


- closes [HAPPY-193
](https://linear.app/happychain/issue/HAPPY-193/pulldown-menu-permissions-and-disconnect-persists-after-hiding-the)

### Description

- fix(iframe):  ensure the secondary menu is closed when : 
   - the user signs out 
   - the wallet is closed


<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.


**Environment**
OS: Manjaro (6.2)

**Browsers**:
(desktop) Firefox 134.0.0

**Demo** : 
Vanilla JS

- [x] Case 1: secondary actions menu closes after we close the wallet
  1. Connect wallet
  2. Open secondary actions menu
  3. Click outside of the wallet
  4. The wallet should close 
  5. Open the wallet again 
  6. The secondary actions menu should not be open, the homepage should be entirely visible
- [x] Case 2: secondary actions menu closes after the user disconnects
  1. Connect wallet
  2. Open secondary actions menu
  3. Click on "Disconnect"/"Logout"
  4. Click on the "Yes, sign me out"/"Yes log me out" button
  5. The user should get disconnected, the wallet should close
  6. Open the wallet again 
  7. The authentication options should appear
  8. Connect using any preferred options
  9. The secondary actions menu should not be open, the homepage should be entirely visible

---

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
