### PR TITLE
safari-closed-wallet-fix

### DIFF
--- a/packages/sdk-vanillajs/lib/wallet/WalletFrame.tsx
+++ b/packages/sdk-vanillajs/lib/wallet/WalletFrame.tsx
@@ -36,9 +36,9 @@ export const WalletFrame = ({ dragging }: WalletFrameProps) => {
             {/* Base64 to avoid any bundle issues and network requests */}
             <img src={icon64x64} alt="HappyChain Logo" className="wallet-logo" inert={true} />
             <div className="wallet-iframe-wrapper" inert={!isOpen}>
-                <span ref={iframe}>
+                <div ref={iframe} style="width: 100%; height: 100%;">
                     <slot name="frame" />
-                </span>
+                </div>
             </div>
         </div>
     )


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes <linear issue URL>

### Description

This fixes the wallet display on Safari. Previously it wasn't displayed correctly, now it should render the same as other browsers.

Before this fix the happy icon when the wallet was closed would not be visible, and opening the wallet wouldn't be full screen

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

  Safari+MacOS

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
