### PR TITLE
remove re-exports from react-sdk

### DIFF
--- a/demos/react/src/App.tsx
+++ b/demos/react/src/App.tsx
@@ -1,5 +1,6 @@
 import { abis, deployment } from "@happy.tech/contracts/mocks/sepolia"
-import { ConnectButton, happyChainSepolia, useHappyChain } from "@happy.tech/react"
+import { happyChainSepolia } from "@happy.tech/core"
+import { ConnectButton, useHappyChain } from "@happy.tech/react"
 import { useEffect, useMemo, useState } from "react"
 import { createPublicClient, createWalletClient, custom } from "viem"
 import { gnosis } from "viem/chains"

--- a/demos/react/src/main.tsx
+++ b/demos/react/src/main.tsx
@@ -1,7 +1,8 @@
 import React from "react"
 import ReactDOM from "react-dom/client"
 
-import { HappyWalletProvider, happyChainSepolia, happyProvider } from "@happy.tech/react"
+import { happyChainSepolia, happyProvider } from "@happy.tech/core"
+import { HappyWalletProvider } from "@happy.tech/react"
 
 import App from "./App.tsx"
 

--- a/packages/core/lib/index.ts
+++ b/packages/core/lib/index.ts
@@ -47,8 +47,6 @@ export type {
     EIP1193UserRejectedRequestError,
 } from "@happy.tech/wallet-common"
 
-export type { ProviderRpcErrorCode as ViemProviderRpcErrorCode } from "viem"
-
 export { happyWagmiConnector, createHappyChainWagmiConfig } from "./wagmi/happyWagmiConfig"
 
 export type { BadgeProps } from "./badge/define"

--- a/packages/react/lib/index.ts
+++ b/packages/react/lib/index.ts
@@ -1,16 +1,3 @@
 export { HappyWalletProvider, useHappyChain } from "./components/HappyWalletProvider"
+
 export { ConnectButton } from "./components/Badge"
-
-export * from "@happy.tech/core"
-
-export type {
-    HappyUser,
-    Chain,
-    EIP1193ChainDisconnectedError,
-    EIP1193ChainNotRecognizedError,
-    EIP1193DisconnectedError,
-    EIP1193UnauthorizedError,
-    EIP1193UnsupportedMethodError,
-    EIP1193UserRejectedRequestError,
-    GenericProviderRpcError,
-} from "@happy.tech/core"


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes <linear issue URL>

### Description

remove core re-exports from react sdk

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

demo (react)

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
