### PR TITLE
use-strict-ports

### DIFF
--- a/apps/docs/vocs.config.ts
+++ b/apps/docs/vocs.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "vocs"
 export default defineConfig({
     rootDir: "src",
     title: "HappyChain Docs 🤠",
+    vite: {
+        server: { port: 4000, strictPort: true },
+        preview: { port: 4000, strictPort: true },
+    },
     socials: [
         {
             link: "https://x.com/HappyChainDevs",

--- a/apps/iframe/vite.config.ts
+++ b/apps/iframe/vite.config.ts
@@ -32,8 +32,8 @@ export default defineConfig(({ command, mode }) => {
             // between branches.
             exclude: command === "serve" ? ["@happy.tech/worker"] : [],
         },
-        server: { port: 5160 },
-        preview: { port: 4160 },
+        server: { port: 5160, strictPort: true },
+        preview: { port: 5160, strictPort: true },
         plugins: [
             TanStackRouterVite(),
             react({ babel: { presets: ["jotai/babel/preset"] } }),

--- a/demos/js/vite.config.ts
+++ b/demos/js/vite.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from "vite"
 
 // https://vitejs.dev/config/
-export default defineConfig({})
+export default defineConfig({
+    server: { port: 6001, strictPort: true },
+    preview: { port: 6001, strictPort: true },
+})

--- a/demos/react/vite.config.ts
+++ b/demos/react/vite.config.ts
@@ -3,5 +3,7 @@ import { defineConfig } from "vite"
 
 // https://vitejs.dev/config/
 export default defineConfig({
+    server: { port: 6002, strictPort: true },
+    preview: { port: 6002, strictPort: true },
     plugins: [react()],
 })

--- a/demos/vue/vite.config.ts
+++ b/demos/vue/vite.config.ts
@@ -3,5 +3,7 @@ import { defineConfig } from "vite"
 
 // https://vitejs.dev/config/
 export default defineConfig({
+    server: { port: 6003, strictPort: true },
+    preview: { port: 6003, strictPort: true },
     plugins: [vue()],
 })

--- a/makefiles/bundling.mk
+++ b/makefiles/bundling.mk
@@ -52,7 +52,7 @@ DIST_DEPS := $(shell find . \
 FORCE_UDPATE := $(shell test -f node_modules/.tmp/.dev && echo force_update)
 
 dist: $(DIST_DEPS) $(FORCE_UDPATE)
-	@happybuild --config build.config.ts;
+	@NODE_ENV=production happybuild --config build.config.ts;
 	@# force updates modified_at timestamp
 	@if [ -d $@ ]; then touch $@; else mkdir -p $@; fi;
 

--- a/makefiles/vite.mk
+++ b/makefiles/vite.mk
@@ -32,7 +32,7 @@ preview: node_modules dist ## Serves the production mode package
 # You can add dependencies to this rule in the Makefile in which `vite.mk` is inluded.
 dist: $(shell find . -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.css" -o -name "*.json" -o -name "*.js" -o -name "*.html" -o -name "*.vue" \) -not -path "./dist/*")
 	@$(TSC_BIN) --build;
-	@bunx --bun vite build;
+	@NODE_ENV=production bunx --bun vite build;
 	@# force updates modified_at timestamp;
 	@if [ -d $@ ]; then touch $@; else mkdir -p $@; fi;
 

--- a/packages/core/.env.example
+++ b/packages/core/.env.example
@@ -1,2 +1,2 @@
 # only used in production builds. In dev see lib/config.ts for default values
-IFRAME_URL=http://localhost:4160
+IFRAME_URL=http://localhost:5160


### PR DESCRIPTION
### Linked Issues


### Description

This PR uses fixed/strict ports for demos and the iframe. 
The new ports are the same in both `dev` and `prod` and are defined as follows:

- iframe:     5160
- demo-js:    6001
- demo-react: 6002
- demo-vue:   6003


NOTE: you will likely need to update your `packages/core/.env` file 
to fix the `IFRAME_URL` from port 4160 to 5160 

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

- iframe.dev
- iframe.prod
- demo-js.dev
- demo-js.prod
- demo-react.dev
- demo-react.prod
- demo-vue.dev
- demo-vue.prod

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.

</details>
