### PR TITLE
Fix: random() reverts once every 3 blocks

### DIFF
--- a/apps/randomness/src/DrandService.ts
+++ b/apps/randomness/src/DrandService.ts
@@ -74,7 +74,7 @@ export class DrandService {
         }
 
         const url = `${env.EVM_DRAND_URL}/rounds/${round}`
-        const response = await ResultAsync.fromPromise(fetchWithRetry(url, {}, 2, 2000), unknownToError)
+        const response = await ResultAsync.fromPromise(fetchWithRetry(url, {}, 3, 1000, 3000), unknownToError)
 
         if (response.isErr()) {
             return err(DrandError.NetworkError)


### PR DESCRIPTION
### Description

This PR aims to solve the issue that Aodhgan found in the randomness service, where every 3 blocks, for one of them, the random() function reverts. This occurs in the testnet but not locally, making it quite difficult to determine what is happening.

The error occurs because the drand value is not found. This happens every 3 blocks because, in every 3-block cycle, one of them has a lower margin of error. Specifically, the time we have to include the drand value is only about 2.3 seconds from its generation, whereas for the other drands, it is 3.3 and 4.3 seconds, respectively. This makes the 2.3-second case the most problematic.

2.3 seconds should be more than enough time to include the drand value. However, I have detected that when a drand value is requested immediately after being emitted, the drand network can take up to 1.6 seconds to return it. This would cause us to exceed the time limit, given that the current timeout is set to 1 second. For this reason, I have increased the timeout to 2 seconds.


- Include all relevant context (but no need to repeat the issue's content).
- Draw attention to new, noteworthy & unintuitive elements.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.
- [x] D4. An appropriate Changeset has been generated (and committed) for changes that touch npm published packages (currently `pacakges/core` and `packages/react`), see [here](https://github.com/HappyChainDevs/happychain/tree/master/.changeset) for more info.

</details>
