### PR TITLE
submitter basic middleware

### DIFF
--- a/apps/submitter/src/server.ts
+++ b/apps/submitter/src/server.ts
@@ -1,13 +1,47 @@
 import { Hono } from "hono"
+import { every, except } from "hono/combine"
+import { logger as loggerMiddleware } from "hono/logger"
+import { prettyJSON as prettyJSONMiddleware } from "hono/pretty-json"
+import { requestId as requestIdMiddleware } from "hono/request-id"
+import { timeout as timeoutMiddleware } from "hono/timeout"
+import { timing as timingMiddleware } from "hono/timing"
+import env from "./env"
 import { logger } from "./logger"
 import accountsApi from "./routes/api/accounts"
 
-export const app = new Hono().route("/api/v1/accounts", accountsApi)
+export const app = new Hono()
+    // middleware
+    .use(
+        except(
+            // don't run these during testing
+            () => env.NODE_ENV === "test",
+            every(
+                timingMiddleware(), // measure response times
+                loggerMiddleware(), // log all calls to the console
+                prettyJSONMiddleware(), // add '?pretty' to any json endpoint to prettyprint
+            ),
+        ),
+    )
+    .use(timeoutMiddleware(10_000))
+    .use(requestIdMiddleware())
+
+    // Routes
+    .get("/", (c) => c.text("Greetings from Happychain. Visit https://docs.happy.tech for more information."))
+    .route("/api/v1/accounts", accountsApi)
 
 app.notFound((c) => c.text("These aren't the droids you're looking for", 404))
 app.onError((err, c) => {
-    logger.warn(err)
-    return c.json({ message: "Something Happened" }, 500)
+    logger.warn({ requestId: c.get("requestId"), url: c.req.url }, err)
+
+    const response =
+        env.NODE_ENV === "production"
+            ? {
+                  message: `Something Happened, file a report with this key to find out more: ${c.get("requestId")}`,
+                  requestId: c.get("requestId"),
+              }
+            : { requestId: c.get("requestId"), url: c.req.url, err }
+
+    return c.json(response, 500)
 })
 
 export type AppType = typeof app


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes <linear issue URL>

### Description

Added middleware to the submitter server to enhance functionality and monitoring:

- Request timing measurements
- Console logging for all API calls
- Pretty JSON printing (via `?pretty` query parameter)
- Request ID tracking
- 10-second timeout for all requests
- Environment-aware middleware loading (disabled during tests)

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.
- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.
- [x] D4. An appropriate Changeset has been generated (and committed) for changes that touch npm published packages (currently `pacakges/core` and `packages/react`), see [here](https://github.com/HappyChainDevs/happychain/tree/master/.changeset) for more info.

</details>