### PR TITLE
add submitter client

### DIFF
--- a/apps/submitter/src/clients/index.ts
+++ b/apps/submitter/src/clients/index.ts
@@ -1,3 +1,16 @@
+import type { PublicClient as BasePublicClient, WalletClient as BaseWalletClient } from "viem"
+import { http, createPublicClient, createWalletClient } from "viem"
 import { localhost } from "viem/chains"
+import { createSubmitterClient } from "./submitterClient/createSubmitterClient"
 
 export const chain = localhost
+
+export const config = { chain, transport: http() } as const
+
+export const submitterClient = createSubmitterClient()
+
+export type PublicClient = BasePublicClient<typeof config.transport, typeof config.chain>
+export const publicClient: PublicClient = createPublicClient(config)
+
+export type WalletClient = BaseWalletClient<typeof config.transport, typeof config.chain, undefined>
+export const walletClient: WalletClient = createWalletClient(config)

--- a/apps/submitter/src/clients/submitterClient/actions/estimateSubmitGas.ts
+++ b/apps/submitter/src/clients/submitterClient/actions/estimateSubmitGas.ts
@@ -1,0 +1,13 @@
+import { simulateSubmit } from "./simulateSubmit"
+
+export async function estimateSubmitGas(request: Parameters<typeof simulateSubmit>[0]) {
+    if (!request.account) throw new Error("Account Not Found - estimateGas")
+    const simulate = await simulateSubmit(request)
+
+    return {
+        executeGasLimit: BigInt(simulate.result.executeGas),
+        gasLimit: BigInt(simulate.result.gas),
+        maxFeePerGas: 1200000000n,
+        submitterFee: 100n,
+    }
+}

--- a/apps/submitter/src/clients/submitterClient/actions/simulateSubmit.ts
+++ b/apps/submitter/src/clients/submitterClient/actions/simulateSubmit.ts
@@ -1,0 +1,81 @@
+import type { happyChainSepolia } from "@happy.tech/wallet-common"
+import { type Account, type SimulateContractParameters, type SimulateContractReturnType, zeroAddress } from "viem"
+import { parseAccount } from "viem/accounts"
+import { publicClient } from "#src/clients"
+import { abis } from "#src/deployments"
+import { parseFromViemError } from "#src/errors/utils"
+import { decodeHappyTx } from "#src/utils/decodeHappyTx"
+import { encodeHappyTx } from "#src/utils/encodeHappyTx"
+
+export async function simulateSubmit(
+    request: Omit<SubmitSimulateParameters, "abi" | "functionName">,
+): Promise<SubmitSimulateReturnType> {
+    if (!request.account) throw new Error("Account Not Found - simulateSubmit")
+    // We simulate using the zero address here so we can bypass future nonce reverts
+    const account = parseAccount(zeroAddress)
+    const requestAccount = parseAccount(request.account)
+
+    const req = {
+        ...request,
+        account,
+        abi: abis.HappyEntryPoint,
+        functionName: "submit",
+    } as SubmitSimulateParameters
+
+    const tx = decodeHappyTx(req.args[0])
+    const needsGasHotfix = tx.paymaster !== tx.account && !tx.gasLimit && !tx.executeGasLimit
+    try {
+        const { request, result } = await publicClient.simulateContract(
+            // TODO: temp fix to inject high gas limits if values are zero (contract bug, should be fixed soon)
+            needsGasHotfix
+                ? {
+                      ...req,
+                      args: [encodeHappyTx({ ...tx, gasLimit: 4000000000n, executeGasLimit: 4000000000n })],
+                  }
+                : req,
+        )
+
+        const decoded = decodeHappyTx(request.args[0])
+        const hasSuccessfulGasEstimation = Boolean(result.gas && result.executeGas)
+        const needsPaymasterGasFilled = Boolean(
+            decoded.paymaster !== decoded.account && !decoded.gasLimit && !decoded.executeGasLimit,
+        )
+        if (needsGasHotfix || (needsPaymasterGasFilled && hasSuccessfulGasEstimation)) {
+            decoded.gasLimit = BigInt(result.gas) * 10n // TODO: contract simulation gas estimation errors
+            decoded.executeGasLimit = BigInt(result.executeGas) * 10n
+        }
+        const args = [encodeHappyTx(decoded)]
+
+        return {
+            request: {
+                ...request,
+                // potentially updated gas values
+                args,
+                // restore original account, instead of zeroAddress which was used
+                account: requestAccount,
+            } as unknown as typeof request,
+            result,
+        }
+    } catch (_err) {
+        throw parseFromViemError(_err) || _err
+    }
+}
+
+type SubmitSimulateParameters = SimulateContractParameters<
+    typeof abis.HappyEntryPoint,
+    "submit",
+    readonly [`0x${string}`],
+    typeof happyChainSepolia,
+    undefined,
+    Account
+>
+
+type SubmitSimulateReturnType = SimulateContractReturnType<
+    typeof abis.HappyEntryPoint,
+    "submit",
+    readonly [`0x${string}`],
+    typeof happyChainSepolia,
+    undefined,
+    undefined,
+    Account
+>

--- a/apps/submitter/src/clients/submitterClient/actions/submit.ts
+++ b/apps/submitter/src/clients/submitterClient/actions/submit.ts
@@ -1,0 +1,31 @@
+import type { happyChainSepolia } from "@happy.tech/wallet-common"
+import type { Account, WriteContractParameters } from "viem"
+import { parseAccount } from "viem/accounts"
+import { walletClient } from "#src/clients"
+import { abis } from "#src/deployments"
+import { parseFromViemError } from "#src/errors/utils"
+
+export async function submit(request: Omit<SubmitWriteParameters, "abi" | "functionName">): Promise<`0x${string}`> {
+    const { account: account_, ...params } = request
+    if (!account_) throw new Error("Account Not Found - submit")
+    const account = account_ ? parseAccount(account_) : null
+
+    try {
+        return await walletClient.writeContract({
+            ...params,
+            abi: abis.HappyEntryPoint,
+            functionName: "submit",
+            account,
+        } as WriteContractParameters)
+    } catch (_err) {
+        throw parseFromViemError(_err) || _err
+    }
+}
+
+type SubmitWriteParameters = WriteContractParameters<
+    typeof abis.HappyEntryPoint,
+    "submit",
+    readonly [`0x${string}`],
+    typeof happyChainSepolia,
+    Account
+>

--- a/apps/submitter/src/clients/submitterClient/actions/waitForSubmitReceipt.ts
+++ b/apps/submitter/src/clients/submitterClient/actions/waitForSubmitReceipt.ts
@@ -1,0 +1,90 @@
+import type { Hex } from "viem"
+import { publicClient } from "#src/clients"
+import type { HappyTx } from "#src/tmp/interface/HappyTx"
+import type { HappyTxReceipt } from "#src/tmp/interface/HappyTxReceipt"
+import { TransactionTypeName } from "#src/tmp/interface/common_chain"
+import { EntryPointStatus } from "#src/tmp/interface/status"
+
+function isValidTransactionType(type: string): type is TransactionTypeName {
+    return type in TransactionTypeName
+}
+
+export async function waitForSubmitReceipt(params: WaitForReceiptParameters): Promise<HappyTxReceipt> {
+    const { txHash, happyTxHash, happyTx } = params
+
+    const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash, pollingInterval: 500 })
+
+    if (typeof receipt.to !== "string") throw new Error(`[${happyTxHash}] Invalid receipt.to`)
+    if (typeof receipt.contractAddress !== "string") throw new Error(`[${happyTxHash}] Invalid receipt.contractAddress`)
+
+    if (!isValidTransactionType(receipt.type)) throw new Error(`[${happyTxHash}] Invalid receipt.type`)
+
+    // TODO: is this the correct approach?
+    const entrypointLogs = receipt.logs.filter((l) => l.address === receipt.to)
+
+    // TODO: this makes many assumptions (such as it was fully a success)...
+    return {
+        happyTxHash,
+
+        /** Account that sent the HappyTx. */
+        account: happyTx.account,
+
+        /** The nonce of the HappyTx. */
+        nonceTrack: happyTx.nonceTrack,
+        nonceValue: happyTx.nonceValue,
+
+        /** EntryPoint to which the HappyTx was submitted onchain. */
+        entryPoint: receipt.to,
+
+        /** Result of onchain submission of the HappyTx. */
+        status: EntryPointStatus.Success,
+
+        /** Logs emitted by HappyTx. */
+        logs: entrypointLogs,
+
+        /**
+         * The revertData carried by one of our custom error, or the raw deal for
+         * "otherReverted". Empty if `!status.endsWith("Reverted")`.
+         */
+        revertData: "0x",
+
+        /**
+         * The selector carried by one of our custom error.
+         * Empty if `!status.endsWith("Failed")`
+         */
+        failureReason: "0x",
+
+        /** Gas used by the HappyTx */
+        gasUsed: receipt.gasUsed,
+
+        /** Total gas cost for the HappyTx in wei (inclusive submitter fee) */
+        gasCost: receipt.gasUsed * receipt.effectiveGasPrice,
+
+        /**
+         * Receipt for the transaction that carried the HappyTx.
+         * Note that this transaction is allowed to do other things besides
+         * carrying the happyTx, and could potentially have carried multiple happyTxs.
+         */
+        txReceipt: {
+            blobGasPrice: receipt.blobGasPrice,
+            blobGasUsed: receipt.blobGasUsed,
+            blockHash: receipt.blockHash,
+            blockNumber: receipt.blockNumber,
+            contractAddress: receipt.contractAddress,
+            cumulativeGasUsed: receipt.cumulativeGasUsed,
+            effectiveGasPrice: receipt.effectiveGasPrice,
+            from: receipt.from,
+            gasUsed: receipt.gasUsed,
+            logs: receipt.logs.map((l) => ({ ...l, blockNumber: l.blockNumber })),
+            logsBloom: receipt.logsBloom,
+            root: receipt.root,
+            status: receipt.status,
+            to: receipt.to,
+            transactionHash: receipt.transactionHash,
+            transactionIndex: receipt.transactionIndex,
+            type: receipt.type,
+        },
+    }
+}
+
+type WaitForReceiptParameters = { txHash: Hex; happyTx: HappyTx; happyTxHash: Hex }

--- a/apps/submitter/src/clients/submitterClient/createSubmitterClient.ts
+++ b/apps/submitter/src/clients/submitterClient/createSubmitterClient.ts
@@ -1,0 +1,49 @@
+import { estimateSubmitGas } from "./actions/estimateSubmitGas"
+import { simulateSubmit } from "./actions/simulateSubmit"
+import { submit } from "./actions/submit"
+import { waitForSubmitReceipt } from "./actions/waitForSubmitReceipt"
+
+export function createSubmitterClient() {
+    return {
+        /**
+         * Estimates the required gas for the supplied HappyTX.
+         */
+        estimateSubmitGas,
+
+        /**
+         * Simulates/validates a contract interaction. This is useful for retrieving **return data**
+         * and **revert reasons** of contract write functions.
+         *
+         * This function does not require gas to execute and _**does not**_ change the state of the
+         * blockchain.
+         *
+         * Internally, calls viem's simulateContract passing in the happyTx to HappyEntrypoint
+         * with the user account set to the zeroAddress.
+         *
+         * @param parameters - { entryPoint: string, tx: {@link HappyTx}, account: Account}
+         * @returns The simulation result and write request.
+         */
+        simulateSubmit,
+
+        /**
+         * Submits the happy transaction to be executed.
+         *
+         * Internally, uses a viem walletClient to call writeContract,  calling 'submit' on the
+         * HappyEntrypoint passing in the users TX as args.
+         *
+         * __Warning: The `write` internally sends a transaction – it does not validate if the contract
+         * write will succeed (the contract may throw an error). It is highly recommended to
+         * simulate the contract write with submitterClient.simulateSubmit before you execute it.__
+         *
+         * @param client - Client to use
+         * @param parameters - { entryPoint: string, tx: {@link HappyTx}, account: Account}
+         * @returns A Transaction Hash
+         */
+        submit,
+
+        /**
+         * Waits for the Transaction to be included onchain.
+         */
+        waitForSubmitReceipt,
+    }
+}


### PR DESCRIPTION
### Description

Implements a submitter client using viem, enabling transaction submission functionality. The client includes actions for:

- Estimating gas for submissions (WIP)
- Simulating submissions
- Submitting transactions
- Waiting for submission receipts

The implementation uses typed parameters and proper error handling, with temporary hardcoded gas values that will be replaced with actual estimates.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.
- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.
- [x] D4. An appropriate Changeset has been generated (and committed) for changes that touch npm published packages (currently `pacakges/core` and `packages/react`), see [here](https://github.com/HappyChainDevs/happychain/tree/master/.changeset) for more info.

</details>