### PR TITLE
add nonce queue manager

### DIFF
--- a/apps/submitter/src/env.ts
+++ b/apps/submitter/src/env.ts
@@ -15,6 +15,9 @@ const envSchema = z.object({
     APP_PORT: z.coerce.number().default(3001),
     NODE_ENV: z.enum(["production", "development", "test", "cli"]).default("development"),
     LOG_LEVEL: z.enum(["off", "trace", "info", "warn", "error"]).default("info"),
+
+    LIMITS_EXECUTE_BUFFER_LIMIT: z.coerce.number().default(50),
+    LIMITS_EXECUTE_MAX_CAPACITY: z.coerce.number().default(100),
 })
 
 // Validate `process.env` against our schema

--- a/apps/submitter/src/services/nonceManager.ts
+++ b/apps/submitter/src/services/nonceManager.ts
@@ -1,0 +1,111 @@
+import { Map2, Mutex } from "@happy.tech/common"
+import type { Address } from "viem/accounts"
+import { publicClient } from "#src/clients"
+import { abis } from "#src/deployments"
+import env from "#src/env"
+import type { HappyTx } from "#src/tmp/interface/HappyTx"
+import type { PendingHappyTxInfo } from "#src/tmp/interface/submitter_pending"
+import { computeHappyTxHash } from "#src/utils/getHappyTxHash"
+
+type NonceTrack = bigint
+type NonceValue = bigint
+
+const MAX_WAIT_TIMEOUT_MS = 30_000
+
+let totalCapacity = 0n
+const nonces = new Map2<Address, NonceTrack, NonceValue>()
+const nonceMutexes = new Map2<Address, NonceTrack, Mutex>()
+
+const pendingTxMap = new Map2<
+    Address,
+    NonceTrack,
+    Map<NonceValue, { hash: `0x${string}`; resolve: (value: unknown) => void; reject: () => void }>
+>()
+
+export function getPendingTransactions(account: Address) {
+    const tx = pendingTxMap.getAll(account)
+    if (!tx) return []
+    return Array.from(tx.entries()).flatMap(([nonceTrack, txMap]) => {
+        return Array.from(txMap.entries()).flatMap(([nonceValue, tx]) => {
+            return {
+                nonceTrack,
+                nonceValue,
+                hash: tx.hash,
+                submitted: false,
+            } satisfies PendingHappyTxInfo
+        })
+    })
+}
+
+async function getOnchainNonce(account: Address, nonceTrack: NonceTrack) {
+    return await publicClient.readContract({
+        address: account,
+        abi: abis.ScrappyAccount,
+        functionName: "getNonce",
+        args: [nonceTrack],
+    })
+}
+
+export async function isTxBlocked(_tx: HappyTx) {
+    const account = _tx.account
+    const nonceTrack = _tx.nonceTrack
+
+    // TODO: is this race condition if 2 txs are submitted at the same time?
+    // does one mutex get overwritten with the other?
+    const mutex = nonceMutexes.getOrSet(account, nonceTrack, () => new Mutex())
+
+    return await mutex.locked(async () => {
+        const nonce = await nonces.getOrSetAsync(account, nonceTrack, () => getOnchainNonce(account, nonceTrack))
+        return _tx.nonceValue > nonce
+    })
+}
+
+export async function waitUntilUnblocked(tx: HappyTx) {
+    // wait until the tx is unblocked. when unblocked, we call 'resolve'
+    return new Promise((resolve, reject) => {
+        const track = pendingTxMap.getOrSet(tx.account, tx.nonceTrack, new Map())
+        if (track.size >= env.LIMITS_EXECUTE_BUFFER_LIMIT) throw new Error("bufferExceeded")
+        if (totalCapacity >= env.LIMITS_EXECUTE_MAX_CAPACITY) throw new Error("bufferExceeded")
+
+        // reject previous tx so it can be replaced
+        const value = track.get(tx.nonceValue)
+        if (value) value.reject()
+
+        // Timeout tx after 30 seconds if it hasn't been executed
+        const timeout = setTimeout(() => reject(new Error("transaction timeout")), MAX_WAIT_TIMEOUT_MS)
+
+        track.set(tx.nonceValue, {
+            hash: computeHappyTxHash(tx),
+            resolve: () => {
+                clearTimeout(timeout)
+                resolve(undefined)
+            },
+            reject: () => {
+                clearTimeout(timeout)
+                reject(new Error("transaction rejected"))
+            },
+        })
+        pendingTxMap.set(tx.account, tx.nonceTrack, track)
+        totalCapacity++
+    })
+}
+
+export function incrementLocalNonce(tx: HappyTx) {
+    // TX is completed, remove from running total
+    totalCapacity--
+
+    const account = tx.account
+    const nonceTrack = tx.nonceTrack
+    const nextNonce = tx.nonceValue + 1n
+
+    nonces.set(account, nonceTrack, nextNonce)
+
+    const track = pendingTxMap.get(account, nonceTrack)
+    const pendingTx = track?.get(nextNonce)
+
+    if (!track || !pendingTx) return
+
+    pendingTx.resolve(undefined)
+    track.delete(nextNonce)
+    if (!track.size) pendingTxMap.delete(account, nonceTrack)
+}

--- a/apps/submitter/src/tests/utils.ts
+++ b/apps/submitter/src/tests/utils.ts
@@ -1,0 +1,43 @@
+import { type Address, zeroAddress } from "viem"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
+import { encodeFunctionData, parseEther } from "viem/utils"
+import { abis, deployment } from "#src/deployments"
+import type { HappyTx } from "#src/tmp/interface/HappyTx"
+
+export function createTestAccount(privateKey = generatePrivateKey()) {
+    const account = privateKeyToAccount(privateKey)
+    const nonceMap = new Map()
+    return {
+        account,
+        createHappyTx(nonceTrack = 0n) {
+            const nonceValue = nonceMap.get(nonceTrack) ?? 0n
+            const tx = createMockTokenAMintHappyTx(account.address, nonceValue)
+            nonceMap.set(nonceTrack, nonceValue + 1n)
+            return tx
+        },
+    }
+}
+
+function createMockTokenAMintHappyTx(account: Address, nonceValue: bigint): HappyTx {
+    return {
+        account,
+        dest: deployment.MockTokenA,
+        nonceTrack: 0n, // using as default
+        nonceValue: nonceValue,
+        value: 0n,
+        // paymaster is default
+        paymaster: zeroAddress,
+        executeGasLimit: 0n,
+        gasLimit: 0n,
+        maxFeePerGas: 0n,
+        submitterFee: 0n,
+        callData: encodeFunctionData({
+            abi: abis.MockTokenA,
+            functionName: "mint",
+            args: [account, parseEther("0.001")],
+        }),
+        paymasterData: "0x",
+        validatorData: "0x",
+        extraData: "0x",
+    }
+}

--- a/apps/submitter/src/tmp/interface/submitter_pending.ts
+++ b/apps/submitter/src/tmp/interface/submitter_pending.ts
@@ -2,8 +2,9 @@ import type { Address, Hash, UInt256 } from "./common_chain"
 
 export type PendingHappyTxInfo = {
     hash: Hash
-    nonce: UInt256
-    submitted: number
+    nonceTrack: UInt256
+    nonceValue: UInt256
+    submitted: boolean
 }
 
 /**

--- a/apps/submitter/src/utils/getHappyTxHash.ts
+++ b/apps/submitter/src/utils/getHappyTxHash.ts
@@ -1,0 +1,23 @@
+import { keccak256 } from "viem/utils"
+import type { HappyTx } from "#src/tmp/interface/HappyTx"
+import { encodeHappyTx } from "./encodeHappyTx"
+
+// with paymaster, don't include gas values in the signature!
+const paymasterGasData = {
+    executeGasLimit: 0n,
+    gasLimit: 0n,
+    maxFeePerGas: 0n,
+    submitterFee: 0n,
+} as const
+
+export function computeHappyTxHash(happyTx: HappyTx): `0x${string}` {
+    // Don't include validator data in the signature so that pre & post signing are the same
+
+    const isSelfSigning = happyTx.paymaster === happyTx.account
+
+    const hashData: HappyTx = isSelfSigning
+        ? { ...happyTx, validatorData: "0x" }
+        : { ...happyTx, validatorData: "0x", ...paymasterGasData }
+
+    return keccak256(encodeHappyTx(hashData))
+}


### PR DESCRIPTION
### Description

Introduces a new nonce queue management system that handles transaction submission ordering and buffering. The system:

- Manages transaction queues based on account and nonce track
- Enforces buffer limits per track and total capacity constraints
- Handles nonce fetching and caching to prevent redundant chain calls
- Provides automatic pruning of overflowing queues
- Implements error handling for common scenarios (capacity exceeded, buffer limits, nonce range violations)

Key features:
- Track-based queue management with active buffer tracking
- Promise-based interface for async processing
- Automatic cleanup and resource management
- Built-in protection against nonce conflicts and out-of-range values

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.
- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.
- [x] D4. An appropriate Changeset has been generated (and committed) for changes that touch npm published packages (currently `pacakges/core` and `packages/react`), see [here](https://github.com/HappyChainDevs/happychain/tree/master/.changeset) for more info.

</details>