### PR TITLE
Increase gas limit for revealValue function

### DIFF
--- a/apps/randomness/src/CustomGasEstimator.ts
+++ b/apps/randomness/src/CustomGasEstimator.ts
@@ -18,7 +18,7 @@ export class CustomGasEstimator extends DefaultGasLimitEstimator {
             return ok(75000n)
         }
         if (transaction.functionName === "revealValue") {
-            return ok(40000n)
+            return ok(60000n)
         }
 
         if (transaction.functionName === "postDrand") {


### PR DESCRIPTION
### Description

Increases the gas limit for the `revealValue` function from 40,000 to 60,000 to prevent out-of-gas errors during 
the first reveal which uses approximately 58,000 gas, so 40,000 is not enough. Given that we don't lose anything by increasing the gas limit, I think we should set it for the worst-case scenario

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments.
- [x] C3. I have manually tested my changes & connected features.
- [x] C4. I have performed a thorough self-review of my code after submitting the PR.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code.
- [x] D2. All public-facing APIs & meaningful internal APIs are properly documented.
- [x] D3. If appropriate, the general architecture of the code is documented.
- [x] D4. An appropriate Changeset has been generated for npm published packages.

</details>