### PR TITLE
Fix bug in TransactionSubmissionFailed hook

### DIFF
--- a/packages/txm/lib/TransactionCollector.ts
+++ b/packages/txm/lib/TransactionCollector.ts
@@ -56,13 +56,16 @@ export class TransactionCollector {
                     maxPriorityFeePerGas,
                 })
 
-                if (submissionResult.isErr() && !submissionResult.error.flushed) {
+                if (submissionResult.isErr()) {
                     eventBus.emit(Topics.TransactionSubmissionFailed, {
                         transaction,
                         description: submissionResult.error.description,
                         cause: submissionResult.error.cause,
                     })
-                    this.txmgr.nonceManager.returnNonce(nonce)
+
+                    if (!submissionResult.error.flushed) {
+                        this.txmgr.nonceManager.returnNonce(nonce)
+                    }
                 }
             }),
         )


### PR DESCRIPTION
### Description

We had a bug in the TXM where we weren't sending the TransactionSubmissionFailed error if the transaction failed during submission but the nonce had already been flushed.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.
- [x] D4. An appropriate Changeset has been generated (and committed) for changes that touch npm published packages (currently `pacakges/core` and `packages/react`), see [here](https://github.com/HappyChainDevs/happychain/tree/master/.changeset) for more info.

</details>