### PR TITLE
Add success field to ExecutionOutput

### DIFF
--- a/contracts/src/happy-accounts/interfaces/IHappyAccount.sol
+++ b/contracts/src/happy-accounts/interfaces/IHappyAccount.sol
@@ -5,10 +5,12 @@ import {HappyTx} from "../core/HappyTx.sol";
 
 /**
  * Execution Output
+ * @param success     - Whether the call specified by the happyTx was successful.
  * @param gas         - The amount of gas used by the {IHappyAccount.execute} function.
  * @param revertData  - The associated revert data if the call specified by the happyTx reverts; otherwise, it is empty.
  */
 struct ExecutionOutput {
+    bool success;
     uint256 gas;
     bytes revertData;
 }

--- a/contracts/src/happy-accounts/samples/ScrappyAccount.sol
+++ b/contracts/src/happy-accounts/samples/ScrappyAccount.sol
@@ -116,7 +116,7 @@ contract ScrappyAccount is
     // ====================================================================================================
     // EXTERNAL FUNCTIONS
 
-    function validate(HappyTx memory happyTx) external returns (bytes4) {
+    function validate(HappyTx memory happyTx) external onlyFromEntryPoint returns (bytes4) {
         if (happyTx.account != address(this)) {
             return WrongAccount.selector;
         }
@@ -164,6 +164,7 @@ contract ScrappyAccount is
             return output;
         }
 
+        output.success = true;
         output.gas = startGas - gasleft() + EXECUTE_INTRINSIC_GAS_OVERHEAD;
 
         // [LOGGAS_INTERNAL] uint256 _startGasEmulate = gasleft(); // To simulate the gasleft() at the top of the function


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-392/boop-hep-sets-callstatus-=-callsucceeded-if-revertdata-=-0x00000000

### Description

Add `bool success` to `ExecutionOutput` struct in `IHappyAccount.sol`, to signal if inner call inside `execute()` was a success or not.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.
- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
</details>
