### PR TITLE
Update max return data size inside HappyEntryPoint

### DIFF
--- a/contracts/src/happy-accounts/core/HappyEntryPoint.sol
+++ b/contracts/src/happy-accounts/core/HappyEntryPoint.sol
@@ -104,31 +104,37 @@ contract HappyEntryPoint is ReentrancyGuardTransient {
     // Must be used to avoid gas exhaustion via return data.
     using ExcessivelySafeCall for address;
 
+    // ====================================================================================================
+    // CONSTANTS
+
     /**
      * @dev Maximum amount of data allowed to be returned from {IHappyAccount.validate}.
      * The returned data is as follows:
-     * 1st slot: bytes4 selector (minimum 32 bytes are neded to decode the return data)
+     * 1st slot: bytes4 selector (minimum 32 bytes are used by the error selector)
+     * 2nd slot onwards: 224 bytes reserved for parameters of the error (if any)
      */
-    uint16 private constant MAX_VALIDATE_RETURN_DATA_SIZE = 32;
+    uint16 private constant MAX_VALIDATE_RETURN_DATA_SIZE = 256;
 
     /**
      * @dev Maximum amount of data allowed to be returned from {IPaymaster.payout}.
      * The returned data is as follows:
-     * 1st slot: bytes4 selector (minimum 32 bytes are neded to decode the return data)
+     * 1st slot: bytes4 selector (minimum 32 bytes are used by the error selector)
+     * 2nd slot onwards: 224 bytes reserved for parameters of the error (if any)
      */
-    uint16 private constant MAX_PAYOUT_RETURN_DATA_SIZE = 32;
+    uint16 private constant MAX_PAYOUT_RETURN_DATA_SIZE = 256;
 
     /**
      * @dev Maximum amount of data allowed to be returned from {IHappyAccount.execute}
      * The encoding of the returned {ExecutionOutput} struct is as follows:
      *
      * 1st slot: Offset for the struct (returned values are encoded as a tuple)
-     * 2nd slot: {ExecutionOutput.gas}
-     * 3rd slot: offset for revertData from where the struct begins
-     * 4th slot: {ExecutionOutput.revertData.Length}
-     * 5th slot (onwards): {ExecutionOutput.revertData} (max 256 bytes)
+     * 2nd slot: {ExecutionOutput.success}
+     * 3rd slot: {ExecutionOutput.gas}
+     * 4th slot: offset for revertData from where the struct begins
+     * 5th slot: {ExecutionOutput.revertData.Length}
+     * 6th slot (onwards): {ExecutionOutput.revertData} (max 256 bytes)
      */
-    uint16 private constant MAX_EXECUTE_REVERT_DATA_SIZE = 384;
+    uint16 private constant MAX_EXECUTE_REVERT_DATA_SIZE = 416;
 
     /**
      * Fixed max gas overhead for the logic around the ExcessivelySafeCall to


### PR DESCRIPTION
### Linked Issues

- NOISSUE: From the discussion on slack b/w Norswap, Reed and I.

### Description

Earlier max_validation_return_data_size was 32, which was just enough for one `bytes4` selector.

So if returned error from `validate()` was of the form `ValidationFailed(InvalidSignature)`, 
1st 32 bytes: 0x<validation_failed_selector_in_8_bytes><....0 padded 28 bytes>
2nd 32 bytes: 0x<Invalid_signature_selector_in_8_bytes><....0 padded 28 bytes>

This couldn't be fit into 32 bytes, hence, I've raised these limits to 256 bytes (a realistic value, shouldn't be an issue in terms of memory expansion of OOG, since we use ~416 bytes for `execute` anyways), as this should be enough to realistically parse any returnData from the smartAccounts.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).
### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.
- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.
</details>
