### PR TITLE
Update nonceAhead logic within ScrappyAccount.sol

### DIFF
--- a/contracts/src/happy-accounts/samples/ScrappyAccount.sol
+++ b/contracts/src/happy-accounts/samples/ScrappyAccount.sol
@@ -82,7 +82,7 @@ contract ScrappyAccount is
     address public immutable ENTRYPOINT;
 
     /// Mapping from track => nonce
-    mapping(uint192 => uint256) private nonceValue;
+    mapping(uint192 => uint256) public nonceValue;
 
     // ====================================================================================================
     // MODIFIERS
@@ -210,14 +210,6 @@ contract ScrappyAccount is
 
     receive() external payable {
         emit Received(msg.sender, msg.value);
-    }
-
-    // ====================================================================================================
-    // VIEW FUNCTIONS
-
-    /// Returns the current nonce value for a given nonce track
-    function getNonceValue(uint192 nonceTrack) external view returns (uint256) {
-        return nonceValue[nonceTrack];
     }
 
     // ====================================================================================================


### PR DESCRIPTION
### Linked Issues

- NOISSUE

### Description

My thoughts 🤔 

If we explicitly treat nonceTrack and nonceValue as separate (and don't have the need of 4337 to expose a complete `uint256 nonce` in our userOps (happyTx), we might not need an external `getNonce()` or `getNonceValue()` functions at all.

Made the mapping private, and made getNonce* functions external

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.
- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) for changes that touch npm published packages (currently `packages/core` and `packages/react`), see [here](https://github.com/HappyChainDevs/happychain/tree/master/.changeset) for more info.

</details>
