### PR TITLE
add show-config flag to happybuild

### DIFF
--- a/.changeset/blue-words-camp.md
+++ b/.changeset/blue-words-camp.md
@@ -1,0 +1,5 @@
+---
+"@happy.tech/happybuild": minor
+---
+
+add show-config cli flag

--- a/support/happybuild/bin/happybuild.ts
+++ b/support/happybuild/bin/happybuild.ts
@@ -8,6 +8,11 @@ import { getConfigs } from "../lib/config/getConfigs"
 // load config
 const { default: configs } = await import(join(process.cwd(), cliArgs.config))
 
+if (cliArgs["show-config"]) {
+    process.stdout.write(JSON.stringify(getConfigs(configs, cliArgs), null, 2))
+    process.exit(0)
+}
+
 if (!cliArgs.watch) {
     await build({ configs, options: cliArgs })
     process.exit(0)

--- a/support/happybuild/lib/cli-args.ts
+++ b/support/happybuild/lib/cli-args.ts
@@ -11,6 +11,10 @@ export const { values: cliArgs } = parseArgs({
             type: "boolean",
             default: false,
         },
+        "show-config": {
+            type: "boolean",
+            default: false,
+        },
     },
     strict: true,
     allowPositionals: true,


### PR DESCRIPTION
### Linked Issues

### Description

Added a `--show-config` flag to the happybuild CLI tool that prints the resolved configuration as JSON and exits. This makes it easier to debug configuration issues by allowing users to see the exact configuration that will be used for the build.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.
- [x] D4. An appropriate Changeset has been generated (and committed) for changes that touch npm published packages (currently `packages/core` and `packages/react`), see [here](https://github.com/HappyChainDevs/happychain/tree/master/.changeset) for more info.

</details>