### PR TITLE
feat: increase bundler polling rate

### DIFF
--- a/packages/bundler/configs/config.happySepolia.json
+++ b/packages/bundler/configs/config.happySepolia.json
@@ -17,5 +17,6 @@
     "enforce-unique-senders-per-bundle": false,
     "max-gas-per-bundle": "20000000",
     "log-level": "trace",
-    "enable-instant-bundling-endpoint": true
+    "enable-instant-bundling-endpoint": true,
+    "polling-interval": 500
 }


### PR DESCRIPTION
### Linked Issues

During my bundler latency investigation journeys I found this value defaults to 1000ms, which at a 2s block time is the bare minimum for effective sampling. Doubt this will effect the overall system high latency too much but it is worth a shot.

### Description

< DESCRIPTION GOES HERE >

- Include all relevant context (but no need to repeat the issue's content).
- Draw attention to new, noteworthy & unintuitive elements.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.
- [x] D4. An appropriate Changeset has been generated (and committed) for changes that touch npm published packages (currently `packages/core` and `packages/react`), see [here](https://github.com/HappyChainDevs/happychain/tree/master/.changeset) for more info.

</details>
