### PR TITLE
Remove watch mode targets from docs - closes HAPPY-241

### DIFF
--- a/apps/docs/Makefile
+++ b/apps/docs/Makefile
@@ -9,14 +9,8 @@ include ../../makefiles/help.mk
 # Also using concurrently rather than `make -j 3` for the same reason: concurrently restarts
 # the three processes as a group if one crashes.
 dev: ## Serves the docs in watch mode
-	concurrently \
-		--restart-tries -1 \
-		--names "doc-js,doc-react,docs-vue,vocs" \
-		'make typedoc-js.watch'\
-		'make typedoc-react.watch'\
-		'make typedoc-vue.watch'\
-		'make typedoc-txm.watch'\
-		'make vocs.watch';
+	make typedoc;
+	make vocs.watch;
 .PHONY: dev
 
 # precompile API reference docs, then build full vocs output
@@ -63,45 +57,17 @@ typedoc-js:
 	typedoc --options ./typedoc.core.js;
 .PHONY: typedoc-js
 
-# generate JS markdown API reference in watch mode
-typedoc-js.watch:
-	typedoc\
-		--watch\
-		--options ./typedoc.core.js;
-.PHONY: typedoc-js.watch
-
 # generate React markdown API reference
 typedoc-react:
 	typedoc --options ./typedoc.react.js;
 .PHONY: typedoc-react
-
-# generate React markdown API reference in watch mode
-typedoc-react.watch:
-	typedoc\
-		--watch\
-		--options ./typedoc.react.js;
-.PHONY: typedoc-react.watch
 
 # generate Vue markdown API reference
 typedoc-vue:
 	typedoc --options ./typedoc.vue.js;
 .PHONY: typedoc-vue
 
-# generate Vue markdown API reference in watch mode
-typedoc-vue.watch:
-	typedoc\
-		--watch\
-		--options ./typedoc.vue.js;
-.PHONY: typedoc-vue.watch
-
 # generate Transaction Manager markdown API reference
 typedoc-txm:
 	typedoc --options ./typedoc.txm.js;
 .PHONY: typedoc-txm
-
-# generate Transaction Manager markdown API reference in watch mode
-typedoc-txm.watch:
-	typedoc\
-		--watch\
-		--options ./typedoc.txm.js;
-.PHONY: typedoc-txm.watch


### PR DESCRIPTION
### Description

Simplified the documentation development workflow by removing watch mode for TypeDoc generation. Instead of running multiple concurrent TypeDoc watch processes, the `make dev` command now:

1. Generates all TypeDoc documentation once upfront
2. Only runs Vocs in watch mode

This change reduces resource usage during development and simplifies the build process by eliminating the need for the `concurrently` tool to manage multiple watch processes.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) for changes that touch npm published packages (currently `packages/core` and `packages/react`), see [here](https://github.com/HappyChainDevs/happychain/tree/master/.changeset) for more info.

</details>