### PR TITLE
Add BoopExecutionStarted event for log delimiting

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -146,7 +146,8 @@ test-happyAccountFactory:
 .PHONY: test-happyAccountFactory
 
 test-happyAccount-upgradeability:
-	forge test --match-contract UpgradeSCATest -vvv
+	forge test --match-contract UpgradeHappyAccountUUPSProxyTest -vvv
+	forge test --match-contract UpgradeHappyAccountBeaconProxyTest -vvv
 .PHONY: test-happyAccount-upgradeability
 
 test-predictDeploymentAddress:

--- a/contracts/src/boop/core/EntryPoint.sol
+++ b/contracts/src/boop/core/EntryPoint.sol
@@ -137,7 +137,7 @@ contract EntryPoint is Staking, ReentrancyGuardTransient {
         // 4. Execute the call
 
         // Emit event to mark the start of Boop execution for log delimiting, using the hash of the encoded Boop
-        emit BoopExecutionStarted(boop.account, keccak256(encodedBoop));
+        emit BoopExecutionStarted();
 
         bytes memory executeCallData = abi.encodeCall(IAccount.execute, (boop));
         uint256 gasBeforeExecute = gasleft();

--- a/contracts/src/boop/interfaces/EventsAndErrors.sol
+++ b/contracts/src/boop/interfaces/EventsAndErrors.sol
@@ -7,6 +7,12 @@ import {ExtensionType} from "boop/interfaces/Types.sol";
 // ENTRYPOINT EVENTS
 
 /**
+ * This event is emitted by {EntryPoint.submit} just before executing a Boop, to delimit
+ * the Boop execution logs for easier indexing and improved visibility on block explorers.
+ */
+event BoopExecutionStarted();
+
+/**
  * This event exposes a Boop as an event and is emitted by {EntryPoint.submit}, for easier
  * indexing of Boops and easier visibility on block explorers.
  *
@@ -31,12 +37,6 @@ event BoopSubmitted(
     bytes validatorData,
     bytes extraData
 );
-
-/**
- * When {EntryPoint.submit} is about to execute a Boop, emitted to delimit logs from the Boop execution
- * using the {boop.account} and {keccak256(encodedBoop)}.
- */
-event BoopExecutionStarted(address indexed account, bytes32 indexed boopHash);
 
 /**
  * When the {IAccount.execute} call succeeds but reports that the


### PR DESCRIPTION
### Linked Issues

- closes [439](https://linear.app/happychain/issue/HAPPY-439/enable-log-parsing-for-boop)

### Description

Added a new `BoopExecutionStarted` event that is emitted just before a Boop is executed in the EntryPoint contract. This event serves as a log delimiter for Boop execution, making it easier to track and analyze execution flows.

The event includes:
- The account address (indexed)
- The hash of the encoded Boop (indexed)

This addition improves observability and debugging capabilities by providing clear markers in the event logs for when Boop execution begins.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs & meaningful (non-local) internal APIs are properly documented in code
      comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
      in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) for changes that touch npm published packages (currently `packages/core` and `packages/react`), see [here](https://github.com/HappyChainDevs/happychain/tree/master/.changeset) for more info.

</details>