### PR TITLE
Add staging environment and refactor NODE_ENV checks with isProduction utility

### DIFF
--- a/packages/submitter/lib/env/schemas/app.ts
+++ b/packages/submitter/lib/env/schemas/app.ts
@@ -24,7 +24,7 @@ export const appSchema = z.object({
     // Defaults to first EXECUTOR_KEYS at runtime
     PRIVATE_KEY_ACCOUNT_DEPLOYER: z.string().refine(isHexString).optional(),
     APP_PORT: z.coerce.number().default(DEFAULT_APP_PORT),
-    NODE_ENV: z.enum(["production", "development", "test", "cli"]).default(DEFAULT_NODE_ENV),
+    NODE_ENV: z.enum(["production", "staging", "development", "test", "cli"]).default(DEFAULT_NODE_ENV),
     LOG_LEVEL: z.enum(["off", "trace", "info", "warn", "error"]).default(DEFAULT_LOG_LEVEL),
     DATABASE_URL: z.string(),
 })

--- a/packages/submitter/lib/routes/api/accounts/openApi/create.ts
+++ b/packages/submitter/lib/routes/api/accounts/openApi/create.ts
@@ -3,7 +3,7 @@ import { resolver } from "hono-openapi/zod"
 import { validator as zv } from "hono-openapi/zod"
 import { checksum } from "ox/Address"
 import { z } from "zod"
-import env from "#lib/env"
+import { isProduction } from "#lib/utils/isProduction"
 import { isAddress } from "#lib/utils/zod/refines/isAddress"
 import { isHexString } from "#lib/utils/zod/refines/isHexString"
 
@@ -24,9 +24,9 @@ const inputSchema = z.object({
 
 export const description = describeRoute({
     // Experimental option. Disable in production, but useful in development
-    validateResponse: env.NODE_ENV !== "production",
+    validateResponse: !isProduction,
     description: "Create a new account",
-    hide: env.NODE_ENV === "production",
+    hide: isProduction,
     responses: {
         200: {
             description: "Successfully created an account",

--- a/packages/submitter/lib/routes/api/submitter/openApi/estimateGas.ts
+++ b/packages/submitter/lib/routes/api/submitter/openApi/estimateGas.ts
@@ -5,6 +5,7 @@ import { checksum } from "ox/Address"
 import { z } from "zod"
 import env from "#lib/env"
 import { EntryPointStatus, SubmitterErrorStatus } from "#lib/tmp/interface/status"
+import { isProduction } from "#lib/utils/isProduction"
 import { isAddress } from "#lib/utils/zod/refines/isAddress"
 import { toBigInt } from "#lib/utils/zod/transforms/toBigInt"
 import { happyTxInputSchema } from "#lib/validation/schemas/happyTx"
@@ -43,7 +44,7 @@ const outputSchema = z.discriminatedUnion("status", [
 ])
 
 export const description = describeRoute({
-    // validateResponse: env.NODE_ENV !== "production",
+    validateResponse: !isProduction,
     description: "Estimate gas for the supplied HappyTx",
     responses: {
         200: {

--- a/packages/submitter/lib/routes/api/submitter/openApi/execute.ts
+++ b/packages/submitter/lib/routes/api/submitter/openApi/execute.ts
@@ -2,9 +2,9 @@ import { describeRoute } from "hono-openapi"
 import { resolver } from "hono-openapi/zod"
 import { validator as zv } from "hono-openapi/zod"
 import { z } from "zod"
-import env from "#lib/env"
 import { EntryPointStatus } from "#lib/tmp/interface/status"
 import { ExecuteSuccess } from "#lib/tmp/interface/submitter_execute"
+import { isProduction } from "#lib/utils/isProduction"
 import { happyReceiptSchema } from "#lib/validation/schemas/happyReceipt"
 import { inputSchema } from "./submit"
 
@@ -20,7 +20,7 @@ const outputSchema = z.object({
 })
 
 export const description = describeRoute({
-    validateResponse: env.NODE_ENV !== "production",
+    validateResponse: !isProduction,
     description: "Execute HappyTX",
     responses: {
         200: {

--- a/packages/submitter/lib/routes/api/submitter/openApi/pendingByAccount.ts
+++ b/packages/submitter/lib/routes/api/submitter/openApi/pendingByAccount.ts
@@ -3,7 +3,7 @@ import { resolver } from "hono-openapi/zod"
 import { validator as zv } from "hono-openapi/zod"
 import { checksum } from "ox/Address"
 import { z } from "zod"
-import env from "#lib/env"
+import { isProduction } from "#lib/utils/isProduction"
 import { isAddress } from "#lib/utils/zod/refines/isAddress"
 import { pendingTxSchema } from "#lib/validation/schemas/pendingTx"
 
@@ -20,7 +20,7 @@ const outputSchema = z.object({
 })
 
 export const description = describeRoute({
-    validateResponse: env.NODE_ENV !== "production",
+    validateResponse: !isProduction,
     description: "Retrieve pending happy transactions for Account",
     responses: {
         200: {

--- a/packages/submitter/lib/routes/api/submitter/openApi/receiptByHash.ts
+++ b/packages/submitter/lib/routes/api/submitter/openApi/receiptByHash.ts
@@ -2,7 +2,7 @@ import { describeRoute } from "hono-openapi"
 import { resolver, validator as zv } from "hono-openapi/zod"
 import { z } from "zod"
 import { DEFAULT_RECEIPT_TIMEOUT_MS } from "#lib/data/defaults"
-import env from "#lib/env"
+import { isProduction } from "#lib/utils/isProduction"
 import { outputSchema, inputSchema as paramSchema } from "./stateByHash"
 
 const querySchema = z.object({
@@ -10,7 +10,7 @@ const querySchema = z.object({
 })
 
 export const description = describeRoute({
-    validateResponse: env.NODE_ENV !== "production",
+    validateResponse: !isProduction,
     description: "Retrieve state by HappyTxHash, waiting if necessary",
     responses: {
         200: {

--- a/packages/submitter/lib/routes/api/submitter/openApi/stateByHash.ts
+++ b/packages/submitter/lib/routes/api/submitter/openApi/stateByHash.ts
@@ -2,8 +2,8 @@ import { describeRoute } from "hono-openapi"
 import { resolver } from "hono-openapi/zod"
 import { validator as zv } from "hono-openapi/zod"
 import { z } from "zod"
-import env from "#lib/env"
 import { StateRequestStatus } from "#lib/tmp/interface/HappyTxState"
+import { isProduction } from "#lib/utils/isProduction"
 import { isHexString } from "#lib/utils/zod/refines/isHexString"
 import { happyTxStateSchema } from "#lib/validation/schemas/happyTxState"
 
@@ -29,7 +29,7 @@ export const outputSchema = z.object({
 // ])
 
 export const description = describeRoute({
-    validateResponse: env.NODE_ENV !== "production",
+    validateResponse: !isProduction,
     description: "Retrieve state by HappyTxHash",
     responses: {
         200: {

--- a/packages/submitter/lib/routes/api/submitter/openApi/submit.ts
+++ b/packages/submitter/lib/routes/api/submitter/openApi/submit.ts
@@ -5,6 +5,7 @@ import { getAddress } from "viem"
 import { z } from "zod"
 import env from "#lib/env"
 import { SubmitSuccess } from "#lib/tmp/interface/submitter_submit"
+import { isProduction } from "#lib/utils/isProduction"
 import { isAddress } from "#lib/utils/zod/refines/isAddress"
 import { isHexString } from "#lib/utils/zod/refines/isHexString"
 import { happyTxInputSchema } from "#lib/validation/schemas/happyTx"
@@ -31,7 +32,7 @@ const outputSchema = z.object({
 })
 
 export const description = describeRoute({
-    validateResponse: env.NODE_ENV !== "production",
+    validateResponse: !isProduction,
     description: "Submits HappyTX",
     responses: {
         200: {

--- a/packages/submitter/lib/server.ts
+++ b/packages/submitter/lib/server.ts
@@ -13,6 +13,7 @@ import env from "./env"
 import { logger } from "./logger"
 import accountsApi from "./routes/api/accounts"
 import submitterApi from "./routes/api/submitter"
+import { isProduction } from "./utils/isProduction"
 
 const app = new Hono()
     // middleware
@@ -59,10 +60,9 @@ app.onError(async (err, c) => {
     // Unhandled Exceptions - should not occur
     return c.json(
         {
-            error:
-                env.NODE_ENV === "production"
-                    ? `Something Happened, file a report with this key to find out more: ${c.get("requestId")}`
-                    : err.message,
+            error: isProduction
+                ? `Something Happened, file a report with this key to find out more: ${c.get("requestId")}`
+                : err.message,
             requestId: c.get("requestId"),
             url: c.req.url,
         },

--- a/packages/submitter/lib/utils/isProduction.ts
+++ b/packages/submitter/lib/utils/isProduction.ts
@@ -1,0 +1,3 @@
+import env from "../env"
+
+export const isProduction = ["staging", "production"].includes(env.NODE_ENV)


### PR DESCRIPTION
### Description

Added support for a "staging" environment by updating the NODE_ENV schema to include "staging" as a valid value. This change introduces the concept of production-like environments that include both "production" and "staging".

To support this change, a new utility function `isProduction` was created that checks if the current environment is either "production" or "staging". This utility function replaces direct NODE_ENV checks throughout the codebase, ensuring consistent behavior across both production-like environments.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>