### PR TITLE
Remove accessorsFromAtom import and make createKernelAccount private

### DIFF
--- a/apps/iframe/src/state/kernelAccount.ts
+++ b/apps/iframe/src/state/kernelAccount.ts
@@ -1,4 +1,3 @@
-import { accessorsFromAtom } from "@happy.tech/common"
 import { abis } from "@happy.tech/contracts/account-abstraction/sepolia"
 import { WalletType, convertToViemChain } from "@happy.tech/wallet-common"
 import { type Atom, atom } from "jotai"
@@ -27,7 +26,7 @@ import { type AccountWalletClient, getWalletClient, walletClientAtom } from "./w
 
 export type KernelSmartAccount = SmartAccount & EcdsaKernelSmartAccountImplementation<"0.7">
 
-export async function createKernelAccount(
+async function createKernelAccount(
     walletAddress: Address,
     isInjected: boolean,
 ): Promise<KernelSmartAccount | undefined> {
@@ -80,8 +79,6 @@ export const kernelAccountAtom: Atom<Promise<KernelSmartAccount | undefined>> = 
     if (!wallet?.account || !user) return undefined
     return await createKernelAccount(wallet.account.address, user.type === WalletType.Injected)
 })
-
-export const { getValue: getKernelAccount } = accessorsFromAtom(kernelAccountAtom)
 
 export async function getKernelAccountAddress(owner: Address): Promise<Address> {
     const chain = getCurrentChain()


### PR DESCRIPTION
### Description

This PR fixes iframe build step where tsc fails on Atom<KernelAccount>> type as shown below

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/54faca5e-e974-4a03-bcf5-24ecd7934d04.png)

It removes the exported `getKernelAccount` accessor function and makes the `createKernelAccount` function private by removing its export. These changes help clean up the API surface of the kernel account module by restricting access to implementation details that shouldn't be directly used outside the module.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>