### PR TITLE
use serializeBigInt in submitter-client

### DIFF
--- a/packages/submitter-client/lib/client.ts
+++ b/packages/submitter-client/lib/client.ts
@@ -13,6 +13,7 @@ import type {
     SubmitInput,
     SubmitOutput,
 } from "@happy.tech/submitter/client"
+import { serializeBigInt } from "@happy.tech/submitter/client"
 import { env } from "./env"
 import { ApiClient } from "./utils/api-client"
 import type { Result } from "./utils/neverthrow"
@@ -44,7 +45,7 @@ export async function createAccount(data: CreateAccountInput): Promise<Result<Cr
  */
 export type { SubmitInput, SubmitOutput }
 export async function submit(data: SubmitInput): Promise<Result<SubmitOutput, Error>> {
-    const response = await client.post("/v1/submitter/submit", data)
+    const response = await client.post("/v1/submitter/submit", serializeBigInt(data))
     return response as Result<SubmitOutput, Error>
 }
 
@@ -57,7 +58,7 @@ export async function submit(data: SubmitInput): Promise<Result<SubmitOutput, Er
  */
 export type { ExecuteInput, ExecuteOutput }
 export async function execute(data: ExecuteInput): Promise<Result<ExecuteOutput, Error>> {
-    const response = await client.post("/v1/submitter/execute", data)
+    const response = await client.post("/v1/submitter/execute", serializeBigInt(data))
     return response as Result<ExecuteOutput, Error>
 }
 
@@ -68,7 +69,7 @@ export async function execute(data: ExecuteInput): Promise<Result<ExecuteOutput,
  */
 export type { EstimateGasInput, EstimateGasOutput }
 export async function estimateGas(data: EstimateGasInput): Promise<Result<EstimateGasOutput, Error>> {
-    const response = await client.post("/v1/submitter/simulate", data)
+    const response = await client.post("/v1/submitter/simulate", serializeBigInt(data))
     return response as Result<EstimateGasOutput, Error>
 }
 

--- a/packages/submitter/lib/client.ts
+++ b/packages/submitter/lib/client.ts
@@ -21,3 +21,4 @@ export { StateRequestStatus } from "./tmp/interface/BoopState"
 
 // === UTILITIES ===================================================================================
 export { computeBoopHash } from "./utils/computeBoopHash"
+export { serializeBigInt } from "./utils/serializeBigInt"


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

Added `serializeBigInt` utility to properly handle BigInt values when making API requests. The utility is now used in the `submit`, `execute`, and `estimateGas` functions to ensure BigInt values are correctly serialized before being sent to the server.

- Imported the `serializeBigInt` utility from `@happy.tech/submitter/client`
- Applied the serialization to all API calls that might contain BigInt values
- Exported the utility from the main package for broader use

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>