### PR TITLE
Switch from submitter-client to boop-sdk and update local development setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,10 +150,10 @@ format: ts.format contracts.format ## Formats code and tries to fix code quality
 ##@ Demos & Apps
 
 submitter.dev: setup.ts shared.dev
-	cd contracts && make setup;
-	make anvil > /dev/null 2>&1 &
-	cd contracts && make deploy-boop;
-	cd contracts && make deploy-mocks;
+	# cd contracts && make setup;
+	# make anvil > /dev/null 2>&1 &
+	# cd contracts && make deploy-boop;
+	# cd contracts && make deploy-mocks;
 
 	cd apps/submitter && make migrate;
 	cd apps/submitter && make dev;

--- a/apps/iframe/src/requests/approved.ts
+++ b/apps/iframe/src/requests/approved.ts
@@ -1,5 +1,5 @@
+import type { ExecuteOutput } from "@happy.tech/boop-sdk"
 import { HappyMethodNames, PermissionNames } from "@happy.tech/common"
-import type { ExecuteOutput } from "@happy.tech/submitter-client"
 import {
     EIP1193DisconnectedError,
     EIP1193ErrorCodes,
@@ -105,6 +105,7 @@ export async function dispatchHandlers(request: PopupMsgs[Msgs.PopupApprove]) {
 
             const response = await sendToWalletClient({ ...request, payload: request.payload })
             // Currently this fails: web3Auth is hardcoded to the default intial chain.
+
             setCurrentChain(chains[chainId])
             return response
         }

--- a/apps/iframe/src/requests/injected.ts
+++ b/apps/iframe/src/requests/injected.ts
@@ -1,11 +1,5 @@
+import { type Boop, EntryPointStatus, StateRequestStatus, state as boopState, estimateGas } from "@happy.tech/boop-sdk"
 import { HappyMethodNames, PermissionNames } from "@happy.tech/common"
-import {
-    type Boop,
-    EntryPointStatus,
-    StateRequestStatus,
-    state as boopState,
-    estimateGas,
-} from "@happy.tech/submitter-client"
 import {
     EIP1193DisconnectedError,
     EIP1193ErrorCodes,

--- a/apps/iframe/src/requests/permissionless.ts
+++ b/apps/iframe/src/requests/permissionless.ts
@@ -1,11 +1,5 @@
+import { type Boop, EntryPointStatus, StateRequestStatus, state as boopState, estimateGas } from "@happy.tech/boop-sdk"
 import { HappyMethodNames, PermissionNames } from "@happy.tech/common"
-import {
-    type Boop,
-    EntryPointStatus,
-    StateRequestStatus,
-    state as boopState,
-    estimateGas,
-} from "@happy.tech/submitter-client"
 import {
     EIP1193DisconnectedError,
     type EIP1193RequestResult,

--- a/apps/iframe/src/requests/sessionKeys.ts
+++ b/apps/iframe/src/requests/sessionKeys.ts
@@ -1,5 +1,5 @@
+import type { ExecuteOutput } from "@happy.tech/boop-sdk"
 import type { Address } from "@happy.tech/common"
-import type { ExecuteOutput } from "@happy.tech/submitter-client"
 import { type Hex, encodeFunctionData } from "viem"
 import { extensibleAccountAbi, sessionKeyValidator, sessionKeyValidatorAbi } from "#src/constants/contracts"
 import { sendBoop } from "#src/requests/boop"

--- a/apps/iframe/src/services/boopsHistory.ts
+++ b/apps/iframe/src/services/boopsHistory.ts
@@ -1,4 +1,4 @@
-import { EntryPointStatus, type ExecuteOutput } from "@happy.tech/submitter-client"
+import { EntryPointStatus, type ExecuteOutput } from "@happy.tech/boop-sdk"
 import type { Address, Hash } from "viem"
 import { StorageKey, storage } from "./storage"
 
@@ -32,11 +32,16 @@ export function addPendingBoop(account: Address, pendingBoop: Omit<PendingBoop, 
         createdAt: Date.now(),
         status: "submitted",
     }
-
-    const savedBoops = storage.get(StorageKey.Boops) || {}
+    const savedBoops = unserializeBigInt(storage.get(StorageKey.Boops) || {})
     const accountBoops = savedBoops[account] || []
+    // @ts-ignore
     savedBoops[account] = [...accountBoops, entry]
-    storage.set(StorageKey.Boops, savedBoops)
+    try {
+        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        storage.set(StorageKey.Boops, serializeBigInt(savedBoops as any))
+    } catch (err) {
+        console.log({ err })
+    }
 }
 
 export function markBoopAsConfirmed(account: Address, value: bigint, receipt: ExecuteOutput): void {
@@ -70,8 +75,9 @@ export function markBoopAsFailed(
 }
 
 function updateBoopStatus(account: Address, boopHash: Hash, update: Partial<BoopEntry>): void {
-    const savedBoops = storage.get(StorageKey.Boops) || {}
+    const savedBoops = unserializeBigInt(storage.get(StorageKey.Boops) || {})
     const accountBoops = savedBoops[account] || []
+    // @ts-ignore
     const updatedBoops = accountBoops.map((boop: BoopEntry) => {
         if (boop.boopHash === boopHash) {
             return { ...boop, ...update }
@@ -79,6 +85,51 @@ function updateBoopStatus(account: Address, boopHash: Hash, update: Partial<Boop
         return boop
     })
 
+    // @ts-ignore
     savedBoops[account] = updatedBoops
-    storage.set(StorageKey.Boops, savedBoops)
+    // @ts-ignore
+    storage.set(StorageKey.Boops, serializeBigInt(savedBoops))
+}
+
+// Utility type to transform all bigint fields to string
+type ReplaceBigIntWithString<T> = {
+    [K in keyof T]: T[K] extends bigint ? string : T[K] extends object ? ReplaceBigIntWithString<T[K]> : T[K]
+}
+
+// Utility functions to serialize and deserialize bigint values
+function serializeBigInt<T>(obj: T): ReplaceBigIntWithString<T> {
+    if (typeof obj === "bigint") {
+        return `#bigint.${obj.toString()}` as ReplaceBigIntWithString<T>
+    } else if (Array.isArray(obj)) {
+        return obj.map((item) => serializeBigInt(item)) as unknown as ReplaceBigIntWithString<T>
+    } else if (obj !== null && typeof obj === "object") {
+        const serializedObj = {} as Record<string, unknown>
+        for (const key in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                serializedObj[key] = serializeBigInt((obj as T)[key])
+            }
+        }
+        return serializedObj as ReplaceBigIntWithString<T>
+    }
+    return obj as ReplaceBigIntWithString<T>
+}
+type ReplaceStringWithBigInt<T> = {
+    [K in keyof T]: T[K] extends bigint ? string : T[K] extends object ? ReplaceStringWithBigInt<T[K]> : T[K]
+}
+
+function unserializeBigInt<T>(obj: T): ReplaceStringWithBigInt<T> {
+    if (typeof obj === "string" && obj.startsWith("#bigint.")) {
+        return BigInt(obj.replace(/^#bigint\./, "")) as ReplaceStringWithBigInt<T>
+    } else if (Array.isArray(obj)) {
+        return obj.map((item) => unserializeBigInt(item)) as unknown as ReplaceStringWithBigInt<T>
+    } else if (obj !== null && typeof obj === "object") {
+        const serializedObj = {} as Record<string, unknown>
+        for (const key in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                serializedObj[key] = unserializeBigInt((obj as T)[key])
+            }
+        }
+        return serializedObj as ReplaceStringWithBigInt<T>
+    }
+    return obj as ReplaceStringWithBigInt<T>
 }

--- a/apps/iframe/src/services/boopsReceiptsCache.ts
+++ b/apps/iframe/src/services/boopsReceiptsCache.ts
@@ -1,5 +1,5 @@
+import type { Boop, BoopReceipt } from "@happy.tech/boop-sdk"
 import { FIFOCache } from "@happy.tech/common"
-import type { Boop, BoopReceipt } from "@happy.tech/submitter-client"
 import type { Hash } from "viem"
 
 /** Cache Boop receipts - store both the receipt & original transaction */

--- a/apps/iframe/src/state/boopAccount.ts
+++ b/apps/iframe/src/state/boopAccount.ts
@@ -1,5 +1,5 @@
+import { createAccount } from "@happy.tech/boop-sdk"
 import { accessorsFromAtom } from "@happy.tech/common"
-import { createAccount } from "@happy.tech/submitter-client"
 import { type Atom, atom } from "jotai"
 import type { Address } from "viem"
 import { userAtom } from "./user"

--- a/apps/iframe/src/state/boopHistory.ts
+++ b/apps/iframe/src/state/boopHistory.ts
@@ -1,5 +1,5 @@
+import type { ExecuteOutput } from "@happy.tech/boop-sdk"
 import { createBigIntStorage } from "@happy.tech/common"
-import type { ExecuteOutput } from "@happy.tech/submitter-client"
 import { atom } from "jotai"
 import { atomWithStorage } from "jotai/utils"
 import type { Address, Hash } from "viem"

--- a/apps/iframe/src/state/chains.ts
+++ b/apps/iframe/src/state/chains.ts
@@ -8,11 +8,15 @@ import { StorageKey } from "../services/storage"
 
 export function getChainFromSearchParams(): ChainParameters {
     const chainId = new URLSearchParams(window.location.search).get("chainId")
+    const chainKey = chainId && `0x${BigInt(chainId).toString(16)}`
 
     const chains = getChains()
-    return chainId && chainId in chains //
-        ? chains[chainId]
-        : defaultChains.defaultChain
+    const found =
+        chainKey && chainKey in chains //
+            ? chains[chainKey]
+            : defaultChains.defaultChain
+
+    return found
 }
 
 function getDefaultChainsRecord() {
@@ -47,6 +51,7 @@ export const currentChainAtom: WritableAtom<
     [AddEthereumChainParameter | Readonly<AddEthereumChainParameter> | undefined],
     void
 > = atom(getChainFromSearchParams(), (_get, set, newChain) => {
+    console.log("set currentChainAtom", newChain)
     set(currentChainAtom, newChain)
     if (!newChain || !("URLSearchParams" in window)) return
     // Update the URL with the new chain ID

--- a/demos/react/src/demo-components/ChainSwitchingDemo.tsx
+++ b/demos/react/src/demo-components/ChainSwitchingDemo.tsx
@@ -1,11 +1,11 @@
-import { happyChainSepolia } from "@happy.tech/core"
+import { devnet, happyChainSepolia } from "@happy.tech/core"
 import { toast } from "sonner"
 import { gnosis } from "viem/chains"
 import { walletClient } from "../clients"
 
 const ChainSwitchingDemo = () => {
     async function addChain() {
-        await walletClient.addChain({ chain: gnosis })
+        await walletClient.addChain({ chain: devnet })
         toast.success(`Chain details added: ${gnosis.id}.`)
     }
     async function addConflictedChain() {

--- a/demos/react/src/demo-components/SessionKeyDemo.tsx
+++ b/demos/react/src/demo-components/SessionKeyDemo.tsx
@@ -1,5 +1,5 @@
-import { abis, deployment } from "@happy.tech/contracts/mocks/sepolia"
-import { happyChainSepolia, requestSessionKey } from "@happy.tech/core"
+import { abis, deployment } from "@happy.tech/contracts/mocks/anvil"
+import { devnet, happyChainSepolia, loadAbi, requestSessionKey } from "@happy.tech/core"
 import { useHappyWallet } from "@happy.tech/react"
 import { Spinner } from "@phosphor-icons/react"
 import { useCallback, useEffect, useState } from "react"
@@ -34,13 +34,31 @@ const SessionKeyDemo = () => {
     }, [updateCounterValue])
 
     async function submitIncrement() {
+        console.log("INCREMENTING")
         if (!walletClient || !user?.address) throw new Error("Wallet not connected")
         return await walletClient.writeContract({
             address: deployment.HappyCounter,
             abi: abis.HappyCounter,
             functionName: "increment",
-            chain: happyChainSepolia,
+            chain: devnet,
         })
+    }
+    async function resetCounter() {
+        console.log("RESETIING")
+        if (!walletClient || !user?.address) throw new Error("Wallet not connected")
+        return await walletClient.writeContract({
+            address: deployment.HappyCounter,
+            abi: abis.HappyCounter,
+            functionName: "reset",
+            chain: devnet,
+        })
+    }
+
+    async function loadAbiStub() {
+        await loadAbi(deployment.HappyCounter, abis.HappyCounter)
+        toast.success(
+            `ABI loaded for ${deployment.HappyCounter}! Click on the Counter buttons to see the ABI in use within the request popup.`,
+        )
     }
 
     async function incrementCounter() {
@@ -82,6 +100,14 @@ const SessionKeyDemo = () => {
 
             <button type="button" onClick={incrementCounter} className="rounded-lg bg-sky-300 p-2 shadow-xl">
                 Counter ++
+            </button>
+
+            <button type="button" onClick={resetCounter} className="rounded-lg bg-sky-300 p-2 shadow-xl">
+                Reset
+            </button>
+
+            <button type="button" onClick={loadAbiStub} className="rounded-lg bg-sky-300 p-2 shadow-xl">
+                Load ABI
             </button>
 
             <div className="col-span-2 text-center mt-2">

--- a/demos/react/src/main.tsx
+++ b/demos/react/src/main.tsx
@@ -1,9 +1,8 @@
+import { happyProvider } from "@happy.tech/core"
+import { HappyWalletProvider } from "@happy.tech/react"
 import React from "react"
 import ReactDOM from "react-dom/client"
 import { Toaster } from "sonner"
-
-import { happyProvider } from "@happy.tech/core"
-import { HappyWalletProvider } from "@happy.tech/react"
 
 import App from "./App.tsx"
 

--- a/packages/submitter/lib/handlers/boop/simulate.ts
+++ b/packages/submitter/lib/handlers/boop/simulate.ts
@@ -1,0 +1,50 @@
+import { type Result, err, ok } from "neverthrow"
+import { deployment } from "#lib/env"
+import { getSelectorFromErrorName } from "#lib/errors/parsedCodes"
+import type { Boop } from "#lib/interfaces/Boop"
+import type { SimulationInput, SimulationOutput } from "#lib/interfaces/boop_simulate"
+import { SubmitterErrorStatus, isSubmitterError } from "#lib/interfaces/status"
+import { boopNonceManager } from "#lib/services"
+import { encodeBoop } from "#lib/utils/encodeBoop"
+import { simulateBoop } from "./simulateBoop"
+
+export async function simulate(data: SimulationInput): Promise<Result<SimulationOutput, SimulationOutput>> {
+    const entryPoint = data.entryPoint ?? deployment.EntryPoint
+
+    console.log({ entryPoint })
+    const simulation = await simulateBoop(entryPoint, encodeBoop(data.tx))
+    console.log({ simulation })
+    const maxFeePerGas = 1200000000n
+    const submitterFee = 100n
+
+    if (simulation.isOk()) {
+        return ok({
+            status: simulation.value.simulation.status,
+            simulationResult: simulation.value.simulation,
+            maxFeePerGas,
+            submitterFee,
+
+            validateGasLimit: BigInt(simulation.value.result.validateGas),
+            validatePaymentGasLimit: BigInt(simulation.value.result.paymentValidateGas),
+            executeGasLimit: BigInt(simulation.value.result.executeGas),
+            gasLimit: BigInt(simulation.value.result.gas),
+        } satisfies SimulationOutput)
+    }
+
+    if (!simulation.error.simulation || isSubmitterError(simulation.error.simulation.status)) {
+        return err({
+            status: simulation.error.simulation?.status ?? SubmitterErrorStatus.UnexpectedError,
+            simulationResult: simulation.error.simulation,
+        } as SimulationOutput)
+    }
+
+    if (simulation.error.simulation.revertData === getSelectorFromErrorName("InvalidNonce")) {
+        // We don't necessarily need to reset the nonce here, but we do it to be safe.
+        boopNonceManager.resetLocalNonce(data.tx as Boop)
+    }
+
+    return err({
+        status: simulation.error.simulation.status,
+        simulationResult: simulation.error.simulation,
+    } as SimulationOutput)
+}

--- a/packages/submitter/lib/services/SubmitterService.ts
+++ b/packages/submitter/lib/services/SubmitterService.ts
@@ -54,7 +54,7 @@ export class SubmitterService {
 
         const boop = await this.boopTransactionService.findByBoopHashOrThrow(boopHash)
 
-        // TODO this needs a timeout / cancellation policy
+        // TODO: this needs a timeout / cancellation policy
         const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash, pollingInterval: 500 })
 
         if (typeof receipt.to !== "string") throw new InvalidTransactionRecipientError(boopHash)

--- a/packages/submitter/lib/utils/getSimulationError.ts
+++ b/packages/submitter/lib/utils/getSimulationError.ts
@@ -1,0 +1,62 @@
+import type { BaseError, ContractFunctionRevertedError } from "viem"
+import { decodeViemError } from "#lib/errors/utils"
+import type { SimulationResult } from "#lib/interfaces/SimulationResult"
+import { EntryPointStatus, SimulatedValidationStatus, isFailure, isRevert } from "#lib/interfaces/status"
+import type { SubmitParameters } from "./simulation-interfaces"
+
+export function getSimulationError(req: SubmitParameters, err: unknown): SimulationResult | undefined {
+    const entryPoint = req.address
+    const raw = ((err as BaseError)?.cause as ContractFunctionRevertedError)?.raw
+    const decoded = decodeViemError(err)
+
+    const revertData = decoded?.rawArgs?.[0] || raw || "0x"
+
+    if (decoded && isFailure(decoded.errorName as EntryPointStatus)) {
+        return {
+            revertData,
+            entryPoint,
+            status: getEntrypointFailedStatus(decoded),
+            validationStatus: SimulatedValidationStatus.Failed,
+        } satisfies SimulationResult
+    }
+
+    if (decoded && isRevert(decoded.errorName as EntryPointStatus)) {
+        return {
+            revertData,
+            entryPoint,
+            status: getEntrypointRevertStatus(decoded),
+            validationStatus: SimulatedValidationStatus.Reverted,
+        } satisfies SimulationResult
+    }
+
+    return {
+        revertData: raw,
+        entryPoint,
+        status: EntryPointStatus.UnexpectedReverted,
+        validationStatus: SimulatedValidationStatus.UnexpectedReverted,
+    }
+}
+
+function getEntrypointFailedStatus({ errorName }: { errorName?: string } = {}) {
+    switch (errorName) {
+        case "PayoutFailed":
+            return EntryPointStatus.PayoutFailed
+        case "ValidationFailed":
+            return EntryPointStatus.ValidationFailed
+        default:
+            return EntryPointStatus.ExecuteFailed
+    }
+}
+
+function getEntrypointRevertStatus({ errorName }: { errorName?: string } = {}) {
+    switch (errorName) {
+        case "PaymentValidationReverted":
+            return EntryPointStatus.PaymentValidationReverted
+        case "UnexpectedReverted":
+            return EntryPointStatus.UnexpectedReverted
+        case "ValidationReverted":
+            return EntryPointStatus.ValidationReverted
+        default:
+            return EntryPointStatus.ExecuteReverted
+    }
+}

--- a/support/wallet-common/lib/chains/definitions/devnet.ts
+++ b/support/wallet-common/lib/chains/definitions/devnet.ts
@@ -4,5 +4,5 @@ export const devnetDefinition = {
     chainName: "localhost",
     rpcUrls: ["http://127.0.0.1:8545", "ws://127.0.0.1:8545"],
     nativeCurrency: { decimals: 18, name: "Ether", symbol: "ETH" },
-    chainId: "0x7a69", // 31337
+    chainId: "0x539", // 1337
 } satisfies ChainParameters


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR switches the iframe app from using the `@happy.tech/submitter-client` package to the new `@happy.tech/boop-sdk` package. The change includes:

- Updated imports across multiple files to use the new SDK
- Modified the boop submission flow to use the new SDK's `submit` and `receipt` functions
- Added serialization/deserialization utilities for BigInt values in the boops history service
- Updated contract imports to use Anvil deployments instead of Sepolia
- Modified demo components to use the local devnet chain instead of Sepolia
- Commented out contract deployment steps in the Makefile for submitter development
- Updated chain configuration to properly handle the devnet chain ID (1337)

The PR also includes several debugging improvements and temporary fixes to get the local development environment working with the new SDK.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>