### PR TITLE
Add logger and chain configuration to iframe app

### DIFF
--- a/apps/iframe/.env.example
+++ b/apps/iframe/.env.example
@@ -1,4 +1,11 @@
 #######################################
+############ App Config ###############
+#######################################
+
+# Valid values: OFF, ERROR, WARN, INFO, TRACE
+VITE_LOG_LEVEL=INFO
+
+#######################################
 ########## Firebase Setup #############
 #######################################
 VITE_FIREBASE_API_KEY=
@@ -23,3 +30,5 @@ VITE_WEB3AUTH_VERIFIER=
 #######################################
 # VITE_BUNDLER_RPC_URL=http://localhost:8545
 VITE_BUNDLER_RPC_URL=https://bundler.happy.tech
+
+VITE_CHAIN_ID=1337

--- a/apps/iframe/src/connections/InjectedConnector.ts
+++ b/apps/iframe/src/connections/InjectedConnector.ts
@@ -1,3 +1,4 @@
+import type { Hex } from "@happy.tech/common"
 import { createUUID } from "@happy.tech/common"
 import type {
     ConnectionProvider,
@@ -161,7 +162,7 @@ export class InjectedConnector implements ConnectionProvider {
             // get user accounts
             const [address] =
                 request.payload.method === "eth_requestAccounts"
-                    ? (response as `0x${string}`[])
+                    ? (response as Hex[])
                     : await this.detail.provider.request({ method: "eth_accounts" })
 
             const user = await createHappyUserFromWallet(this.id, address)

--- a/apps/iframe/src/connections/firebase/services/FirebaseConnector.ts
+++ b/apps/iframe/src/connections/firebase/services/FirebaseConnector.ts
@@ -1,3 +1,4 @@
+import type { Address } from "@happy.tech/common"
 import {
     type ConnectionProvider,
     type HappyUser,
@@ -118,11 +119,7 @@ export abstract class FirebaseConnector implements ConnectionProvider {
         } satisfies HappyUserDetails
     }
 
-    private static async makeHappyUser(
-        user: HappyUserDetails,
-        addresses: `0x${string}`[],
-        smartAccountAddress: `0x${string}`,
-    ) {
+    private static async makeHappyUser(user: HappyUserDetails, addresses: Address[], smartAccountAddress: Address) {
         return {
             ...user,
             // web3 details

--- a/apps/iframe/src/connections/firebase/workers/web3auth.sw.ts
+++ b/apps/iframe/src/connections/firebase/workers/web3auth.sw.ts
@@ -1,4 +1,5 @@
 import "./web3auth.polyfill"
+import type { Address } from "@happy.tech/common"
 import { waitForCondition } from "@happy.tech/wallet-common"
 import { worker } from "@happy.tech/worker/runtime"
 import { tssLib } from "@toruslabs/tss-dkls-lib"
@@ -53,7 +54,7 @@ ethereumSigningProvider.setupProvider(makeEthereumSigner(web3Auth))
  *  Global mutable variables/state
  */
 let state: "connecting" | "connected" | "disconnected" | "disconnecting" = "disconnected"
-let _addresses: `0x${string}`[] = []
+let _addresses: Address[] = []
 
 /**
  * Proxy all provider events to iframe provider

--- a/apps/iframe/src/constants/contracts.ts
+++ b/apps/iframe/src/constants/contracts.ts
@@ -1,0 +1,45 @@
+import { abis as boopAnvilAbis, deployment as boopAnvilDeployment } from "@happy.tech/contracts/boop/anvil"
+import { abis as boopSepoliaAbis, deployment as boopSepoliaDeployment } from "@happy.tech/contracts/boop/sepolia"
+import { devnet, happyChainSepolia } from "@happy.tech/wallet-common"
+
+const chainId = Number(import.meta.env.VITE_CHAIN_ID)
+
+//== Utils==========================================================================================
+
+function getBoopDeployment(chainId: number) {
+    switch (chainId) {
+        case happyChainSepolia.id:
+            return boopSepoliaDeployment
+        case devnet.id:
+            return boopAnvilDeployment
+        default:
+            throw new Error(`Unsupported chainId: ${chainId}. Failed to fetch deployments`)
+    }
+}
+
+function getBoopAbis(chainId: number) {
+    switch (chainId) {
+        case happyChainSepolia.id:
+            return boopSepoliaAbis
+        case devnet.id:
+            return boopAnvilAbis
+        default:
+            throw new Error(`Unsupported chainId: ${chainId}. Failed to fetch deployments`)
+    }
+}
+
+//== Deployment Addresses ==========================================================================
+
+export const deployment = getBoopDeployment(chainId)
+
+export const happyPaymaster = deployment.HappyPaymaster
+export const entryPoint = deployment.EntryPoint
+export const sessionKeyValidator = deployment.SessionKeyValidator
+
+//== Abis ==========================================================================================
+
+export const abis = getBoopAbis(chainId)
+
+export const entryPointAbi = abis.EntryPoint
+export const extensibleAccountAbi = abis.HappyAccountImpl
+export const sessionKeyValidatorAbi = abis.SessionKeyValidator

--- a/apps/iframe/src/utils/logger.ts
+++ b/apps/iframe/src/utils/logger.ts
@@ -1,2 +1,18 @@
-import { Logger } from "@happy.tech/common"
+import { Logger, logLevel } from "@happy.tech/common"
+
+/**
+ * Default at which all logger's log level are set by default if not changed programmatically.
+ * Initialized to the env var VITE_LOG_LEVEL if set, otherwise {@link LogLevel.WARN}.
+ */
+export const defaultLogLevel = logLevel(import.meta.env.VITE_LOG_LEVEL)
+Logger.instance.setLogLevel(defaultLogLevel)
+
+/**
+ * Default logger instance. Also accessible in the browser console via `window.happyLogger`.
+ */
 export const logger = Logger.create("Wallet")
+
+/**
+ * Logger facade for tracing requests.
+ */
+export const reqLogger = Logger.create("Requests")

--- a/apps/iframe/src/vite-env.d.ts
+++ b/apps/iframe/src/vite-env.d.ts
@@ -1,6 +1,11 @@
 /// <reference types="vite/client" />
 
-type ImportMetaEnv = {
+interface ImportMetaEnv {
+    /**
+     * App Config
+     */
+    readonly VITE_LOG_LEVEL: string
+
     /**
      * Firebase Setup
      */
@@ -17,6 +22,8 @@ type ImportMetaEnv = {
     readonly VITE_WEB3AUTH_CLIENT_ID: string
     readonly VITE_WEB3AUTH_NETWORK: "sapphire_mainnet" | "sapphire_devnet"
     readonly VITE_WEB3AUTH_VERIFIER: string
+
+    readonly VITE_CHAIN_ID: string
 }
 
 interface ImportMeta {

--- a/packages/submitter/lib/handlers/boop/execute.ts
+++ b/packages/submitter/lib/handlers/boop/execute.ts
@@ -27,7 +27,7 @@ export async function execute(data: ExecuteInput): Promise<Result<ExecuteOutput,
         return err({ status: SubmitterErrorStatus.UnexpectedError })
     }
 
-    const receipt = await boopReceiptService.findByBoopHashWithTimeout(boopHash, 60_000)
+    const receipt = await boopReceiptService.findByBoopHashWithTimeout(boopHash, 10_000)
 
     if (!receipt || receipt.txReceipt.status !== "success") return err({ status: SubmitterErrorStatus.UnexpectedError })
 

--- a/packages/submitter/lib/tests/submitter_receipt.spec.ts
+++ b/packages/submitter/lib/tests/submitter_receipt.spec.ts
@@ -55,7 +55,7 @@ describe("submitter_receipt", () => {
         const boopHash = computeBoopHash(BigInt(env.CHAIN_ID), signedTx)
 
         // submit transaction but don't wait to complete
-        client.api.v1.boop.execute.$post({ json: { tx: serializeBigInt(signedTx) } })
+        client.api.v1.boop.submit.$post({ json: { tx: serializeBigInt(signedTx) } })
 
         const [stateSimulated, stateResolved] = await Promise.all([
             client.api.v1.boop.receipt[":hash"]

--- a/support/common/lib/index.ts
+++ b/support/common/lib/index.ts
@@ -4,7 +4,7 @@ export { createStorage } from "./services/storage"
 
 // === UTILS =======================================================================================
 
-export { type TaggedLogger, Logger, type LogTag, LogLevel } from "./utils/logger"
+export { type TaggedLogger, Logger, type LogTag, LogLevel, logLevel } from "./utils/logger"
 
 export { atomWithCompare, atomWithCompareAndStorage, accessorsFromAtom, createBigIntStorage } from "./utils/jotai"
 

--- a/support/common/lib/utils/logger.ts
+++ b/support/common/lib/utils/logger.ts
@@ -16,6 +16,14 @@ export enum LogLevel {
 }
 
 /**
+ * Returns the {@link LogLevel} whose name matches the string, or the default level
+ * ({@link LogLevel.WARN}) if the passed string does not denote a LogLevel or is undefined.
+ */
+export function logLevel(logLevelName: string | undefined): LogLevel {
+    return LogLevel[logLevelName as keyof typeof LogLevel] ?? LogLevel.WARN
+}
+
+/**
  * Tags that categorize log messages by subsystem or feature area.
  */
 export type LogTag = string

--- a/support/wallet-common/lib/chains/definitions/happyChainSepolia.ts
+++ b/support/wallet-common/lib/chains/definitions/happyChainSepolia.ts
@@ -7,4 +7,4 @@ export const happyChainSepoliaDefinition = {
     chainId: "0xd8",
     blockExplorerUrls: ["https://explorer.testnet.happy.tech"],
     opStack: true,
-} satisfies ChainParameters
+} as const satisfies ChainParameters

--- a/support/wallet-common/lib/chains/viem/happyChainSepolia.ts
+++ b/support/wallet-common/lib/chains/viem/happyChainSepolia.ts
@@ -84,7 +84,7 @@ const contracts = {
  *
  * Type: {@link Chain}
  */
-export const happyChainSepolia: Chain = {
+export const happyChainSepolia = {
     ...chainConfig,
     id: Number(addChainDefinition.chainId),
     name: addChainDefinition.chainName,
@@ -129,4 +129,4 @@ export const happyChainSepolia: Chain = {
         },
     },
     sourceId,
-}
+} as const satisfies Chain


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR adds logging configuration and chain ID support to the iframe app. Key changes include:

- Added configurable log level via `VITE_LOG_LEVEL` environment variable
- Created a logger module with default and request-specific loggers
- Added chain ID configuration via `VITE_CHAIN_ID` environment variable
- Implemented contract constants that adapt to the configured chain ID
- Updated type definitions to use more specific types from the common package (Address, Hex)
- Reduced the timeout for boop receipt polling from 60s to 10s
- Fixed a test to use the correct API endpoint

These changes improve the configurability of the iframe app and make it easier to work with different chain environments.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>