### PR TITLE
Fix submitter test-watch mode and anvil integration

### DIFF
--- a/packages/submitter/Makefile
+++ b/packages/submitter/Makefile
@@ -3,7 +3,12 @@ include ../../makefiles/formatting.mk
 include ../../makefiles/bundling.mk
 include ../../makefiles/help.mk
 
+# include .env file and export its env vars
+# (-include to ignore error if it does not exist)
 -include .env
+
+# Port at which Anvil will be running
+export ANVIL_PORT ?= 8545
 
 migrate: ## Runs latest migrations
 	@./dist/cli migrate latest
@@ -23,12 +28,36 @@ routes: ## Display all available routes
 .PHONY: routes
 
 test: ## Run the submitter tests
-	@bun test --bail
+	@bun test --preload ./lib/tests/setup-full.ts --bail
 .PHONY: test
 
-test-watch: ## Run the submitter tests
-	@bun test --watch
+# We can't use the beforeAll/afterAll hooks in bun during watch mode, as we deploy the contracts
+# and start anvil in the beforeAll hook, which re-triggers the watch mode, resulting in an infinite loop.
+# here we will instead start anvil if its not running, deploy the contracts, and then run the tests.
+test-watch: ## Run the submitter tests in Watch mode
+	if lsof -ti :$(ANVIL_PORT); then \
+		make deploy-support-contracts;\
+		bun test --preload ./lib/tests/setup-minimal.ts --watch;\
+	else \
+		make start-anvil;\
+		make deploy-support-contracts;\
+		bun test --preload ./lib/tests/setup-minimal.ts --watch;\
+		make kill-anvil;\
+	fi
 .PHONY: test-watch
+
+start-anvil: ## Start anvil
+	@cd ../../ && make anvil > /dev/null 2>&1 &
+.PHONY: start-anvil
+
+kill-anvil: ## Kill an existing Anvil process running at $ANVIL_PORT
+	@lsof -ti :$(ANVIL_PORT) | xargs kill -9 2>/dev/null || true
+.PHONY: kill-anvil
+
+deploy-contracts: ## Deploys the supporting contracts for testing
+	@cd ../../contracts && CONFIG=LOCAL make deploy-boop
+	@cd ../../contracts && CONFIG=LOCAL make deploy-mocks
+.PHONY: deploy-contracts
 
 setup-symlinks::
 	@if ! [ -r ./dist/client.es.js ]; then \

--- a/packages/submitter/lib/tests/setup-full.ts
+++ b/packages/submitter/lib/tests/setup-full.ts
@@ -1,0 +1,27 @@
+import { afterAll, beforeAll } from "bun:test"
+import { migrator } from "#lib/database/utils/migrator"
+import { anvil } from "#lib/utils/test/anvil"
+import { contracts } from "#lib/utils/test/contracts"
+
+// Force some common test environment variables
+process.env.NODE_ENV = "test"
+process.env.DATABASE_URL = ":memory:"
+
+beforeAll(async () => {
+    const { error } = await migrator.migrateToLatest()
+    if (error) throw new Error("[Submitter] Failed to run test migrations", { cause: error })
+
+    /**
+     * This works great for running the tests, however
+     * it breaks when using --watch mode. to run watch mode successfully
+     * you need to run anvil as a separate service and deploy the
+     * contracts manually.
+     */
+
+    await anvil.start()
+    await contracts.deploy()
+})
+
+afterAll(async () => {
+    await anvil.stop()
+})

--- a/packages/submitter/lib/tests/setup-minimal.ts
+++ b/packages/submitter/lib/tests/setup-minimal.ts
@@ -1,0 +1,8 @@
+import { beforeAll } from "bun:test"
+import "./env-bootstrap"
+import { migrator } from "#lib/database/utils/migrator"
+
+beforeAll(async () => {
+    const { error } = await migrator.migrateToLatest()
+    if (error) throw new Error("[Submitter] Failed to run test migrations", { cause: error })
+})

--- a/packages/submitter/lib/utils/test/anvil.ts
+++ b/packages/submitter/lib/utils/test/anvil.ts
@@ -1,8 +1,8 @@
 import { $, sleep } from "bun"
 import { http, createPublicClient } from "viem"
-import { localhost } from "viem/chains"
+import { anvil as anvilChain } from "viem/chains"
 
-const publicClient = createPublicClient({ chain: localhost, transport: http() })
+const publicClient = createPublicClient({ chain: anvilChain, transport: http() })
 
 export async function waitBlocks(minBlocks = 1) {
     const start = await publicClient.getBlockNumber()


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

Improved the test workflow for the submitter package by fixing issues with watch mode. The changes include:

- Added a proper test-watch command that handles starting/stopping anvil and deploying contracts
- Removed the `bunfig.toml` file and moved the preload configuration to the test command
- Modified the test setup to avoid infinite loops in watch mode
- Updated the anvil utility to use the proper chain configuration
- Added helper scripts for starting and stopping anvil
- Created new make targets for managing anvil and deploying support contracts

These changes make it easier to run tests in watch mode without encountering the infinite loop issue that was previously occurring when anvil was started in the beforeAll hook.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>