### PR TITLE
feat(iframe): add request popup for eth_signTypedData_v4 requests

### DIFF
--- a/.changeset/rich-jars-sit.md
+++ b/.changeset/rich-jars-sit.md
@@ -1,0 +1,5 @@
+---
+"@happy.tech/iframe": minor
+---
+
+Add request popup handler for eth_signTypedData_v4.

--- a/apps/iframe/src/components/requests/EthSignTypedDatav4.tsx
+++ b/apps/iframe/src/components/requests/EthSignTypedDatav4.tsx
@@ -1,0 +1,286 @@
+import type { Address } from "@happy.tech/common"
+import { isAddress } from "viem"
+import DisclosureSection from "./common/DisclosureSection"
+import {
+    FormattedDetailsLine,
+    Layout,
+    LinkToAddress,
+    SectionBlock,
+    SubsectionBlock,
+    SubsectionContent,
+    SubsectionTitle,
+} from "./common/Layout"
+import type { RequestConfirmationProps } from "./props"
+
+type TypedData = {
+    domain: Record<string, unknown>
+    types: Record<string, { name: string; type: string }[]>
+    primaryType: string
+    message: Record<string, unknown>
+}
+
+/**
+ * Utility guard to determine if a given value is a non-null object (excluding arrays).
+ *
+ * This is used to safely recurse into nested structs defined in EIP-712 typed data.
+ */
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Renders an individual field in the EIP-712 message.
+ *
+ * If the field is a valid Ethereum address, it is rendered with a clickable explorer link.
+ * Boolean values are color-coded. Arrays are iterated.
+ * Otherwise, it is displayed as a plain string.
+ */
+function renderField(label: string, value: unknown) {
+    if (Array.isArray(value)) {
+        return (
+            <>
+                <SubsectionTitle>{label}</SubsectionTitle>
+                <FormattedDetailsLine>
+                    {value.map((item) => (
+                        <div key={String(item)} className="py-1">
+                            {typeof item === "string" && isAddress(item) ? (
+                                <LinkToAddress address={item}>{item}</LinkToAddress>
+                            ) : (
+                                String(item)
+                            )}
+                        </div>
+                    ))}
+                </FormattedDetailsLine>
+            </>
+        )
+    }
+
+    if (typeof value === "boolean") {
+        return (
+            <>
+                <SubsectionTitle>{label}</SubsectionTitle>
+                <FormattedDetailsLine>
+                    <span className={value ? "text-green-500" : "text-red-500"}>{String(value)}</span>
+                </FormattedDetailsLine>
+            </>
+        )
+    }
+
+    if (typeof value === "string" && isAddress(value)) {
+        return (
+            <>
+                <SubsectionTitle>{label}</SubsectionTitle>
+                <FormattedDetailsLine>
+                    <LinkToAddress address={value}>{value}</LinkToAddress>
+                </FormattedDetailsLine>
+            </>
+        )
+    }
+
+    return (
+        <>
+            <SubsectionTitle>{label}</SubsectionTitle>
+            <FormattedDetailsLine>{String(value)}</FormattedDetailsLine>
+        </>
+    )
+}
+
+/**
+ * Format and display important domain information from the EIP-712 data.
+ */
+function renderDomainInfo(domain: Record<string, unknown>) {
+    return (
+        <SubsectionBlock>
+            <SubsectionTitle>Domain Information</SubsectionTitle>
+            <SubsectionContent>
+                {typeof domain.name === "string" && (
+                    <div>
+                        <SubsectionTitle>Application</SubsectionTitle>
+                        <FormattedDetailsLine>{domain.name}</FormattedDetailsLine>
+                    </div>
+                )}
+                {typeof domain.version === "string" && (
+                    <div>
+                        <SubsectionTitle>Version</SubsectionTitle>
+                        <FormattedDetailsLine>{domain.version}</FormattedDetailsLine>
+                    </div>
+                )}
+                {(typeof domain.chainId === "number" || typeof domain.chainId === "string") && (
+                    <div>
+                        <SubsectionTitle>Chain ID</SubsectionTitle>
+                        <FormattedDetailsLine>{String(domain.chainId)}</FormattedDetailsLine>
+                    </div>
+                )}
+                {typeof domain.verifyingContract === "string" && isAddress(domain.verifyingContract) && (
+                    <div>
+                        <SubsectionTitle>Contract</SubsectionTitle>
+                        <FormattedDetailsLine>
+                            <LinkToAddress address={domain.verifyingContract as Address}>
+                                {domain.verifyingContract}
+                            </LinkToAddress>
+                        </FormattedDetailsLine>
+                    </div>
+                )}
+            </SubsectionContent>
+        </SubsectionBlock>
+    )
+}
+
+/**
+ * Identify and display the potential purpose of this signature request
+ * based on common EIP-712 patterns.
+ */
+function identifySignaturePurpose(typedData: TypedData): React.ReactNode {
+    const { primaryType, types, message } = typedData
+
+    if (primaryType === "Permit" && types.Permit) {
+        const permitFields = types.Permit.map((f) => f.name)
+        if (permitFields.includes("owner") && permitFields.includes("spender") && permitFields.includes("value")) {
+            return (
+                <div className="bg-amber-100 dark:bg-amber-900/30 p-2 rounded-md text-xs">
+                    <p className="font-medium">You're approving an ERC-20 token allowance</p>
+                    <p className="opacity-75">This signature allows the spender to use your tokens.</p>
+                </div>
+            )
+        }
+    }
+
+    if (primaryType.includes("Order") && typeof message.maker === "object" && message.maker !== null) {
+        return (
+            <div className="bg-blue-100 dark:bg-blue-900/30 p-2 rounded-md text-xs">
+                <p className="font-medium">You're signing a marketplace order</p>
+                <p className="opacity-75">This creates an off-chain listing or offer for assets.</p>
+            </div>
+        )
+    }
+
+    return null
+}
+
+/**
+ * Recursively renders an EIP-712 structured data message.
+ *
+ * This function walks the `types` definition provided in the typed data schema and
+ * matches it against the corresponding values in the `message` field.
+ */
+function renderTypedMessage(typeDef: TypedData["types"], typeName: string, message: Record<string, unknown>) {
+    const fields = typeDef[typeName]
+    if (!fields) return null
+
+    return fields.map(({ name, type }) => {
+        const value = message[name]
+
+        if (type.endsWith("[]") && Array.isArray(value)) {
+            const baseType = type.slice(0, -2)
+            if (typeDef[baseType]) {
+                return (
+                    <SubsectionBlock key={name}>
+                        <SubsectionTitle>{name}</SubsectionTitle>
+                        {value.map((item, index) =>
+                            isObject(item) ? (
+                                <div key={String(item)} className="pl-2 border-l-2 border-neutral/20 mt-2">
+                                    <div className="text-xs opacity-50 mb-1">Item {index + 1}</div>
+                                    {renderTypedMessage(typeDef, baseType, item)}
+                                </div>
+                            ) : null,
+                        )}
+                    </SubsectionBlock>
+                )
+            }
+        }
+
+        if (typeDef[type] && isObject(value)) {
+            return (
+                <SubsectionBlock key={name}>
+                    <SubsectionTitle>{name}</SubsectionTitle>
+                    {renderTypedMessage(typeDef, type, value)}
+                </SubsectionBlock>
+            )
+        }
+
+        return (
+            <SubsectionBlock key={name}>
+                <SubsectionContent>{renderField(name, value)}</SubsectionContent>
+            </SubsectionBlock>
+        )
+    })
+}
+
+/**
+ * Component to render a confirmation UI for an `eth_signTypedData_v4` request.
+ *
+ * This request type is used to sign EIP-712 structured data on Ethereum.
+ * The component breaks down and visualizes domain details, message fields, and provides raw JSON.
+ */
+export const EthSignTypedDataV4 = ({
+    method,
+    params,
+    reject,
+    accept,
+}: RequestConfirmationProps<"eth_signTypedData_v4">) => {
+    const [_signerAddress, rawMessage] = params
+    const parsed: TypedData = typeof rawMessage === "string" ? JSON.parse(rawMessage) : rawMessage
+
+    const origin = window.location.hostname === "localhost" ? "http://localhost:6002" : window.location.origin
+
+    const signatureHint = identifySignaturePurpose(parsed)
+    const isHighRiskSignature = false // Placeholder for heuristics
+
+    return (
+        <Layout
+            headline={<>Signature Request</>}
+            description={<>Please review the message you are about to sign.</>}
+            actions={{
+                accept: {
+                    children: "Sign",
+                    onClick: () => accept({ method, params }),
+                },
+                reject: {
+                    children: "Go back",
+                    onClick: reject,
+                },
+            }}
+        >
+            <SectionBlock>
+                <SubsectionBlock>
+                    <SubsectionTitle>Origin</SubsectionTitle>
+                    <FormattedDetailsLine>{origin}</FormattedDetailsLine>
+                </SubsectionBlock>
+
+                {signatureHint && <div className="mb-2">{signatureHint}</div>}
+
+                {isHighRiskSignature && (
+                    <div className="mb-2 bg-red-100 dark:bg-red-900/30 p-2 rounded-md text-xs">
+                        <p className="font-medium text-red-700 dark:text-red-400">⚠️ High-risk signature detected</p>
+                        <p>This signature could potentially allow access to your assets. Verify carefully.</p>
+                    </div>
+                )}
+
+                <SubsectionBlock>
+                    <SubsectionTitle>Interacting with</SubsectionTitle>
+                    <FormattedDetailsLine>
+                        <LinkToAddress address={parsed.domain.verifyingContract as Address} />
+                    </FormattedDetailsLine>
+                </SubsectionBlock>
+
+                {renderDomainInfo(parsed.domain)}
+
+                <SubsectionBlock>
+                    <SubsectionTitle>Message Type</SubsectionTitle>
+                    <FormattedDetailsLine>{parsed.primaryType}</FormattedDetailsLine>
+                </SubsectionBlock>
+
+                <SubsectionBlock>
+                    <SubsectionTitle>Message</SubsectionTitle>
+                    {renderTypedMessage(parsed.types, parsed.primaryType, parsed.message)}
+                </SubsectionBlock>
+            </SectionBlock>
+
+            <DisclosureSection title="Raw Request">
+                <div className="grid gap-4 p-2">
+                    <FormattedDetailsLine isCode>{JSON.stringify(params, null, 2)}</FormattedDetailsLine>
+                </div>
+            </DisclosureSection>
+        </Layout>
+    )
+}

--- a/apps/iframe/src/constants/requestLabels.ts
+++ b/apps/iframe/src/constants/requestLabels.ts
@@ -4,6 +4,7 @@ import { Permissions } from "./permissions"
 export const requestLabels = {
     eth_requestAccounts: "Connect",
     eth_sendTransaction: "Send transaction",
+    eth_signTypedData_v4: "Signature Request",
     personal_sign: "Sign message",
     wallet_addEthereumChain: "Add chain",
     wallet_requestPermissions: "Grant permissions",

--- a/apps/iframe/src/routes/request.lazy.tsx
+++ b/apps/iframe/src/routes/request.lazy.tsx
@@ -2,6 +2,7 @@ import { HappyMethodNames } from "@happy.tech/common"
 import { EIP1193UserRejectedRequestError, Msgs, type PopupMsgs, serializeRpcError } from "@happy.tech/wallet-common"
 import { createLazyFileRoute } from "@tanstack/react-router"
 import { useCallback, useEffect, useState } from "react"
+import { EthSignTypedDataV4 } from "#src/components/requests/EthSignTypedDatav4.tsx"
 import { HappyLoadAbi } from "#src/components/requests/HappyLoadAbi"
 import { HappyRequestSessionKey } from "#src/components/requests/HappyRequestSessionKey"
 import { UnknownRequest } from "#src/components/requests/UnknownRequest.tsx"
@@ -123,6 +124,8 @@ function Request() {
             return <PersonalSign {...props} />
         case "eth_sendTransaction":
             return <EthSendTransaction {...props} />
+        case "eth_signTypedData_v4":
+            return <EthSignTypedDataV4 {...props} />
         case "wallet_switchEthereumChain":
             return <WalletSwitchEthereumChain {...props} />
         case "wallet_addEthereumChain":

--- a/apps/submitter/lib/server/index.ts
+++ b/apps/submitter/lib/server/index.ts
@@ -103,14 +103,14 @@ app.get(
                 description: "Boop Submitter",
             },
             servers: [
-                env.NODE_ENV === "development" && {
-                    url: `http://localhost:${env.APP_PORT}`,
-                    description: "Local server",
-                },
-                env.NODE_ENV === "staging" && {
-                    url: "https://submitter-staging.happy.tech",
-                    description: "Staging server",
-                },
+                // env.NODE_ENV === "development" && {
+                //     url: `http://localhost:${env.APP_PORT}`,
+                //     description: "Local server",
+                // },
+                // env.NODE_ENV === "staging" && {
+                //     url: "https://submitter-staging.happy.tech",
+                //     description: "Staging server",
+                // },
                 { url: "https://submitter.happy.tech", description: "Production server" },
             ].filter(Boolean) as { url: string; description: string }[],
         },

--- a/apps/submitter/lib/server/index.ts
+++ b/apps/submitter/lib/server/index.ts
@@ -103,14 +103,14 @@ app.get(
                 description: "Boop Submitter",
             },
             servers: [
-                // env.NODE_ENV === "development" && {
-                //     url: `http://localhost:${env.APP_PORT}`,
-                //     description: "Local server",
-                // },
-                // env.NODE_ENV === "staging" && {
-                //     url: "https://submitter-staging.happy.tech",
-                //     description: "Staging server",
-                // },
+                env.NODE_ENV === "development" && {
+                    url: `http://localhost:${env.APP_PORT}`,
+                    description: "Local server",
+                },
+                env.NODE_ENV === "staging" && {
+                    url: "https://submitter-staging.happy.tech",
+                    description: "Staging server",
+                },
                 { url: "https://submitter.happy.tech", description: "Production server" },
             ].filter(Boolean) as { url: string; description: string }[],
         },

--- a/support/common/lib/utils/time.ts
+++ b/support/common/lib/utils/time.ts
@@ -4,15 +4,15 @@ const unit = {
     m: 60e3,
     h: 3_600e3,
     d: 86_400e3,
-  } as const;
-  
+} as const
+
 export function formatMs(ms: number, long = false): string {
-    const abs = Math.abs(ms);
+    const abs = Math.abs(ms)
     for (const [abbr, size] of Object.entries(unit).reverse()) {
         if (abs >= size) {
-        const val = Math.round(ms / size);
-        return long ? `${val} ${abbr}${Math.abs(val) !== 1 ? 's' : ''}` : `${val}${abbr}`;
+            const val = Math.round(ms / size)
+            return long ? `${val} ${abbr}${Math.abs(val) !== 1 ? "s" : ""}` : `${val}${abbr}`
         }
     }
-    return `${ms}ms`;
+    return `${ms}ms`
 }


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-500/implement-eth-signedtypeddata-v4-request-frame

### Description

Added support for handling `eth_signTypedData_v4` requests in the iframe component. This implementation:

- Creates a new component `EthSignTypedDatav4.tsx` that renders EIP-712 structured data in a user-friendly format.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>