### PR TITLE
Refactor submitter test setup and fix test-watch mode

### DIFF
--- a/packages/submitter/bunfig.toml
+++ b/packages/submitter/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./lib/utils/test/setup-migrations.ts"]

--- a/packages/submitter/lib/handlers/execute/execute.spec.ts
+++ b/packages/submitter/lib/handlers/execute/execute.spec.ts
@@ -54,6 +54,7 @@ describe("submitter_execute", () => {
             const signedTx = await sign(unsignedTx)
             const result = await client.api.v1.boop.execute.$post({ json: { boop: serializeBigInt(signedTx) } })
             const response = (await result.json()) as any
+            if (result.status !== 200) console.log(response)
             const afterBalance = await getMockTokenABalance(smartAccount)
             expect(response.error).toBeUndefined()
             expect(result.status).toBe(200)
@@ -163,9 +164,6 @@ describe("submitter_execute", () => {
         })
 
         it("can't use a too-low nonce", async () => {
-            // execute tx with nonce, then another with nonce+1, wait for both to complete
-            // this is to ensure that the nonce value is above `0` so that we don't fail for having a
-            // _negative_ nonce
             const tx1 = await sign(createMockTokenAMintBoop(smartAccount, nonceValue, nonceTrack))
             await client.api.v1.boop.execute.$post({ json: { boop: serializeBigInt(tx1) } })
 

--- a/packages/submitter/lib/utils/test/setup-anvil.ts
+++ b/packages/submitter/lib/utils/test/setup-anvil.ts
@@ -1,0 +1,20 @@
+import { afterAll, beforeAll } from "bun:test"
+import { anvil } from "./anvil"
+import { contracts } from "./contracts"
+
+beforeAll(async () => {
+    /**
+     * This works great for running the tests, however
+     * it breaks when using --watch mode. To run watch mode successfully
+     * you need to run anvil as a separate service and deploy the
+     * contracts manually. Then use the `setup-migrations.ts` preload
+     * script instead of this one.
+     */
+
+    await anvil.start()
+    await contracts.deploy()
+})
+
+afterAll(async () => {
+    await anvil.stop()
+})

--- a/packages/submitter/lib/utils/test/setup-migrations.ts
+++ b/packages/submitter/lib/utils/test/setup-migrations.ts
@@ -1,0 +1,11 @@
+import { beforeAll } from "bun:test"
+import { migrator } from "#lib/database/utils/migrator"
+
+// Force some common test environment variables
+process.env.NODE_ENV = "test"
+process.env.DATABASE_URL = ":memory:"
+
+beforeAll(async () => {
+    const { error } = await migrator.migrateToLatest()
+    if (error) throw new Error("[Submitter] Failed to run test migrations", { cause: error })
+})


### PR DESCRIPTION
### Description

Refactored the test setup for the submitter package to improve organization and fix watch mode issues. The changes include:

- Reorganized test setup files by moving them to a more appropriate location in `lib/utils/test/`
- Created separate setup files for different testing scenarios:
  - `setup-anvil.ts` for tests requiring Anvil
  - `setup-migrations.ts` for tests requiring only database migrations
- Updated the Makefile to use the new setup files and simplified the test-watch command
- Fixed the chain configuration in anvil.ts to use localhost instead of anvil chain
- Updated bunfig.toml to use the new preload path

These changes make the testing infrastructure more maintainable and fix issues with watch mode that were causing infinite loops.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>