### PR TITLE
fix boop activity view reactivity

### DIFF
--- a/apps/iframe/.env.example
+++ b/apps/iframe/.env.example
@@ -5,7 +5,7 @@
 # Valid values: OFF, ERROR, WARN, INFO, TRACE
 VITE_LOG_LEVEL=WARN
 
-VITE_CHAIN_ID=1337
+VITE_CHAIN_ID=31337
 
 #######################################
 ########## Firebase Setup #############

--- a/apps/iframe/src/requests/utils/boop.ts
+++ b/apps/iframe/src/requests/utils/boop.ts
@@ -121,7 +121,6 @@ export async function sendBoop(
         reqLogger.trace("boop/execute output", output)
 
         if (output.status !== Onchain.Success) throw new BoopExecutionError(output)
-
         markBoopAsSuccess(output)
         return output.receipt.boopHash
     } catch (error) {

--- a/packages/submitter/lib/env/schemas/deployments.ts
+++ b/packages/submitter/lib/env/schemas/deployments.ts
@@ -13,7 +13,7 @@ export const deploymentsSchema = z.object({
 
     /**
      * The (HTTP) RPC url to use for the chain. Defaults to a well-known RPC if {@link
-     * CHAIN_ID} is known (for now only 1337 (devnet) and 216 (HappyChain Sepolia)).
+     * CHAIN_ID} is known (for now only 31337 (devnet) and 216 (HappyChain Sepolia)).
      *
      * TODO: websocket support
      */


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR updates the default chain ID from 1337 to 31337 in both the iframe app's environment example and the submitter package's deployment schema documentation.

Additionally, it improves the boop history state management by:
- Refactoring the boopsAtom to handle updates more efficiently
- Implementing proper merging of existing and new boops
- Ensuring the UI rerenders correctly when boops are updated
- Removing a blank line in the sendBoop function

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>