### PR TITLE
Simplify nonce handling in submitter execute tests

### DIFF
--- a/packages/submitter/lib/handlers/execute/execute.spec.ts
+++ b/packages/submitter/lib/handlers/execute/execute.spec.ts
@@ -168,20 +168,10 @@ describe("submitter_execute", () => {
             // this is to ensure that the nonce value is above `0` so that we don't fail for having a
             // _negative_ nonce
             const tx1 = await sign(createMockTokenAMintBoop(smartAccount, nonceValue, nonceTrack))
-            const tx2 = await sign(createMockTokenAMintBoop(smartAccount, nonceValue + 1n, nonceTrack))
-            await Promise.all([
-                client.api.v1.boop.execute.$post({
-                    json: { boop: serializeBigInt(tx1) },
-                }),
-                client.api.v1.boop.execute.$post({
-                    json: { boop: serializeBigInt(tx2) },
-                }),
-            ])
+            await client.api.v1.boop.execute.$post({ json: { boop: serializeBigInt(tx1) } })
 
-            const jsonTx = await sign(
-                // mints a different amount of tokens, computes a difference hash, same nonce though
-                createMockTokenAMintBoop(smartAccount, nonceValue + 1n, nonceTrack, 5n * 10n ** 18n),
-            )
+            // mints a different amount of tokens, computes a difference hash, same nonce though
+            const jsonTx = await sign(createMockTokenAMintBoop(smartAccount, nonceValue, nonceTrack, 5n * 10n ** 18n))
             const result = await client.api.v1.boop.execute.$post({ json: { boop: serializeBigInt(jsonTx) } })
             const response = (await result.json()) as any
 


### PR DESCRIPTION
### Description

Simplified the test case in `execute.spec.ts` by removing the parallel transaction submission. The test now sends a single transaction first, then attempts to send another transaction with the same nonce but different parameters. This change makes the test more focused on testing the specific nonce collision scenario without the complexity of parallel requests.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>