### PR TITLE
Refactor boop execution flow to use async receipt handling

### DIFF
--- a/apps/iframe/src/components/interface/home/tabs/views/activity/BoopEntry.tsx
+++ b/apps/iframe/src/components/interface/home/tabs/views/activity/BoopEntry.tsx
@@ -83,7 +83,7 @@ export const BoopEntry = ({ boop }: BoopEntryProps) => {
             )}
             {boop.boopReceipt?.status === Onchain.Success && (
                 <a
-                    href={`${blockExplorerUrl}/tx/${boop.boopReceipt.receipt.evmTxHash}`}
+                    href={`${blockExplorerUrl}/tx/${boop.boopReceipt.evmTxHash}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     title="View on explorer"

--- a/apps/iframe/src/components/interface/home/tabs/views/activity/useClassifyActivity.ts
+++ b/apps/iframe/src/components/interface/home/tabs/views/activity/useClassifyActivity.ts
@@ -90,9 +90,8 @@ function _decodeERC20TransferLog(log: Log) {
 function classifyBoop(boop: StoredBoop): ActivityDetails {
     if (boop?.status !== BoopStatus.Success || boop.boopReceipt.status !== Onchain.Success)
         return { type: OperationType.Failed }
-    const logs = boop.boopReceipt.receipt.logs
 
-    for (const log of logs) {
+    for (const log of boop.boopReceipt.logs) {
         switch (log.topics[0]?.toLowerCase()) {
             case EVENT_SIGNATURES.ERC20_TRANSFER:
                 return { type: OperationType.ERC20Transfer }

--- a/apps/iframe/src/state/boopHistory.ts
+++ b/apps/iframe/src/state/boopHistory.ts
@@ -1,4 +1,4 @@
-import { type ExecuteOutput, type ExecuteSuccess, Onchain } from "@happy.tech/boop-sdk"
+import { type BoopReceipt, Onchain } from "@happy.tech/boop-sdk"
 import { binaryPartition, createBigIntStorage } from "@happy.tech/common"
 import { atom } from "jotai"
 import { getDefaultStore } from "jotai"
@@ -55,7 +55,7 @@ interface IStoredBoop {
     value: bigint
     error?: { message: string; code?: number | string }
     failedAt?: number
-    boopReceipt?: ExecuteOutput
+    boopReceipt?: BoopReceipt
     status: BoopStatus
 }
 export type StoredBoop = PendingBoop | ConfirmedBoop | FailedBoop
@@ -69,7 +69,7 @@ export interface ConfirmedBoop extends IStoredBoop {
     confirmedAt: number
     error?: never
     failedAt?: never
-    boopReceipt: ExecuteOutput
+    boopReceipt: BoopReceipt
     status: BoopStatus.Success
 }
 
@@ -101,13 +101,13 @@ export function addPendingBoop(boop: Omit<PendingBoop, "createdAt" | "status">):
     store.set(boopsAtom, accountBoops)
 }
 
-export function markBoopAsSuccess(receipt: ExecuteSuccess): void {
+export function markBoopAsSuccess(receipt: BoopReceipt): void {
     if (receipt.status !== Onchain.Success) {
         console.error("Cannot mark boop as confirmed: Boop hash is missing.")
         return
     }
 
-    updateBoopStatus(receipt.receipt.boopHash, {
+    updateBoopStatus(receipt.boopHash, {
         status: BoopStatus.Success,
         confirmedAt: Date.now(),
         boopReceipt: receipt,
@@ -115,13 +115,13 @@ export function markBoopAsSuccess(receipt: ExecuteSuccess): void {
 }
 
 export function markBoopAsFailure(
-    failedBoop: Omit<PendingBoop, "createdAt" | "status" | "value">,
+    boopHash: Hash,
     error?: {
         message: string
         code?: number | string
     },
 ): void {
-    updateBoopStatus(failedBoop.boopHash, {
+    updateBoopStatus(boopHash, {
         status: BoopStatus.Failure,
         failedAt: Date.now(),
         error,


### PR DESCRIPTION
### Description

This PR fixes the boop receipt handling in the iframe app to align with the updated boop-sdk API. The main changes include:

- Updated the path to access transaction hash in `BoopEntry.tsx` from `boop.boopReceipt.receipt.txReceipt.transactionHash` to `boop.boopReceipt.txReceipt.transactionHash`
- Modified the logs access in `useClassifyActivity.ts` to use `boop.boopReceipt.logs` directly instead of `boop.boopReceipt.receipt.logs`
- Refactored the boop submission flow in `boop.ts` to use the new API:
  - Changed from `boopClient.execute()` to `boopClient.submit()`
  - Added asynchronous receipt handling with `boopClient.receipt()`
  - Updated error handling for different receipt statuses
- Updated the `markBoopAsFailure` function to accept a hash directly instead of a boop object
- Improved the counter increment logic in `SessionKeyDemo.tsx` to provide optimistic updates and better error handling

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>