### PR TITLE
Fix typo in BoopSubmitted error message and improve BoopReceiptService return type

### DIFF
--- a/apps/iframe/src/components/interface/UserInfo.tsx
+++ b/apps/iframe/src/components/interface/UserInfo.tsx
@@ -49,7 +49,6 @@ const UserInfo = () => {
                         referrerPolicy="no-referrer"
                     />
                 </div>
-
                 <div className="rounded-full absolute bottom-0 end-0 bg-base-200">
                     <img className="h-3 w-auto" src={activeProvider.icon} alt={activeProvider.name} />
                 </div>

--- a/packages/submitter/lib/services/BoopReceiptService.ts
+++ b/packages/submitter/lib/services/BoopReceiptService.ts
@@ -54,7 +54,7 @@ export class BoopReceiptService {
             const fromEntryPoint = log.address.toLowerCase() === deployment.EntryPoint.toLowerCase()
             if (fromEntryPoint && log.topics[0] === BOOP_SUBMITTED_SELECTOR) {
                 const decodedLog = decodeEvent(log)
-                if (!decodedLog) throw new Error("Found BoopSumitted event but could not decode")
+                if (!decodedLog) throw new Error("Found BoopSubmitted event but could not decode")
                 const decodedHash = computeBoopHash(env.CHAIN_ID, decodedLog.args as Boop)
                 if (decodedHash === boopHash) {
                     return filteredLogs
@@ -71,12 +71,12 @@ export class BoopReceiptService {
         return []
     }
 
-    // TODO horrible return type conflict here
-    async insertOrThrow(receipt: BoopReceipt) {
+    // TODO: horrible return type conflict here. DB BoopReceipt is not equal to Spec BoopReceipt
+    async insertOrThrow(receipt: BoopReceipt): Promise<{ id: number | null }> {
         const { txReceipt, ...rest } = receipt
         const receiptToInsert = { ...rest, transactionHash: txReceipt.transactionHash }
         const data = await this.boopReceiptRepository.insert(receiptToInsert)
         if (!data) throw new SubmitterError("Failed to insert receipt")
-        return data
+        return { id: data.id }
     }
 }


### PR DESCRIPTION
### Description

This PR fixes a typo in the error message when decoding a BoopSubmitted event, changing "BoopSumitted" to "BoopSubmitted". It also improves the return type of the `insertOrThrow` method in the BoopReceiptService by explicitly returning an object with an id property, addressing a TODO comment about type conflicts between DB and Spec BoopReceipt types. Additionally, it removes an unnecessary empty line in the UserInfo component.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>