### PR TITLE
update from executeDummyBoop from temp branch

### DIFF
--- a/support/testing/executeDummyBoop.ts
+++ b/support/testing/executeDummyBoop.ts
@@ -4,7 +4,7 @@
  */
 
 import { abis, deployment } from "@happy.tech/contracts/boop/sepolia"
-import { BoopClient, computeBoopHash } from "@happy.tech/boop-sdk"
+import { type ExecuteSuccess, BoopClient, computeBoopHash, Onchain } from "@happy.tech/boop-sdk"
 import { deployment as mockDeployments } from "@happy.tech/contracts/mocks/sepolia"
 import { http, createPublicClient, zeroAddress } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
@@ -58,21 +58,23 @@ async function run() {
         owner: testAccount.address,
         salt: "0x01",
     })
-
-    if (!createAccountResult.isOk()) {
-        throw new Error(createAccountResult.error.message)
+    if (!("address" in createAccountResult)) {
+        throw new Error("Account creation failed: " + JSON.stringify(createAccountResult));
     }
 
-    const tx = await createAndSignMintTx(createAccountResult.value.address)
-    const executeRes = await boopClient.execute({ tx })
+    const tx = await createAndSignMintTx(createAccountResult.address)
+    const executeResult = await boopClient.execute({ boop: tx })
+    
+    if(executeResult.status !== Onchain.Success) {
+        throw new Error(`execute not successful: ${JSON.stringify(executeResult)}`)
+    }
 
-    if (!executeRes.isOk()) {
-        throw new Error(executeRes.error.message)
+    console.log(`Boop: https://explorer.testnet.happy.tech/tx/${(executeResult as ExecuteSuccess).receipt.txReceipt.transactionHash}`)
+
+    const receiptResult = await boopClient.receipt({ hash: (executeResult as ExecuteSuccess).receipt.boopHash })
+    if(!("receipt" in receiptResult)) {
+        throw new Error("Receipt not found: " + JSON.stringify(receiptResult))
     }
-    if (executeRes.value.status !== "submitSuccess") {
-        throw new Error("submit failed")
-    }
-    console.log(`https://explorer.testnet.happy.tech/tx/${executeRes.value.state.receipt.txReceipt.transactionHash}`)
 }
 
 run().then(() => {


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

Created because I thought I was merging into master but was actually a graphite generated temp branch. this was easier and doesnt touch/break anything else


- Include all relevant context (but no need to repeat the issue's content).
- Draw attention to new, noteworthy & unintuitive elements.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>
