### PR TITLE
draft: watch blocks in ReceiptService

### DIFF
--- a/apps/submitter/lib/utils/clients.ts
+++ b/apps/submitter/lib/utils/clients.ts
@@ -1,5 +1,5 @@
 import type { PublicClient as BasePublicClient, WalletClient as BaseWalletClient, Chain } from "viem"
-import { http, createPublicClient, createWalletClient } from "viem"
+import { createPublicClient, createWalletClient, webSocket } from "viem"
 import { anvil, happychainTestnet } from "viem/chains"
 import { env } from "#lib/env"
 
@@ -38,7 +38,7 @@ function getChain(): Chain {
 
 export const chain: Chain = getChain()
 
-export const config = { chain, transport: http() } as const
+export const config = { chain, transport: webSocket() } as const
 
 export type PublicClient = BasePublicClient<typeof config.transport, typeof config.chain>
 export const publicClient: PublicClient = createPublicClient(config)


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

Refactored the `ReceiptService` to use a block watcher instead of polling for transaction receipts. This change:

- Adds a block watcher mechanism that monitors new blocks for relevant transactions
- Replaces the polling approach with a promise-based system that resolves when a matching transaction is found
- Implements a `#handleBlock` method to process transactions in new blocks and identify Boop-related events
- Maintains a map of pending receipts that can be resolved when matching transactions are found
- Switches from HTTP to WebSocket transport for more efficient block watching

This approach should be more efficient and reliable than polling, especially in high-traffic scenarios.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>