### PR TITLE
move SubmitBoop event

### DIFF
--- a/contracts/src/boop/core/EntryPoint.sol
+++ b/contracts/src/boop/core/EntryPoint.sol
@@ -6,7 +6,6 @@ import {Staking} from "boop/core/Staking.sol";
 import {Utils} from "boop/core/Utils.sol";
 import {
     BoopExecutionStarted,
-    BoopSubmitted,
     CallReverted,
     ExecutionRejected,
     ExecutionReverted,
@@ -38,6 +37,35 @@ contract EntryPoint is Staking, ReentrancyGuardTransient {
 
     // ====================================================================================================
     // SUBMIT
+
+    /**
+     * This event exposes a Boop as an event for easier indexing of Boops and visibility on block explorers.
+     *
+     * @dev We deliberately choose to separate all the fields into dedicated arguments instead of
+     * having a single argument with the struct — this enables better display on some block explorers
+     * like Blockscout.
+     *
+     * @dev It is crucial that the fields here be identical to those in the {interfaces/Types.Boop} struct. Because
+     * Solidity refuses to emit events with more than 15 arguments, we simply use the abi-encoding of the struct to emit
+     * this event.
+     */
+    event BoopSubmitted(
+        address account,
+        address dest,
+        address payer,
+        uint256 value,
+        uint192 nonceTrack,
+        uint64 nonceValue,
+        uint256 maxFeePerGas,
+        int256 submitterFee,
+        uint32 gasLimit,
+        uint32 validateGasLimit,
+        uint32 validatePaymentGasLimit,
+        uint32 executeGasLimit,
+        bytes callData,
+        bytes validatorData,
+        bytes extraData
+    );
 
     /**
      * Execute a Boop, and tries to ensure that the submitter (tx.origin) receives payment for

--- a/contracts/src/boop/interfaces/EventsAndErrors.sol
+++ b/contracts/src/boop/interfaces/EventsAndErrors.sol
@@ -13,36 +13,6 @@ import {ExtensionType} from "boop/interfaces/Types.sol";
 event BoopExecutionStarted();
 
 /**
- * This event exposes a Boop as an event and is emitted by {core/EntryPoint.submit}, for easier
- * indexing of Boops and easier visibility on block explorers.
- *
- * @dev We deliberately choose to separate all the fields into dedicated arguments instead of
- * having a single argument with the struct — this enables better display on some block explorers
- * like Blockscout.
- *
- * @dev It is crucial that the fields here be identical to those in the {interfaces/Types.Boop} struct. Because
- * Solidity refuses to emit events with more than 15 arguments, we simply use the abi-encoding of the struct to emit
- * this event.
- */
-event BoopSubmitted(
-    address account,
-    address dest,
-    address payer,
-    uint256 value,
-    uint192 nonceTrack,
-    uint64 nonceValue,
-    uint256 maxFeePerGas,
-    int256 submitterFee,
-    uint32 gasLimit,
-    uint32 validateGasLimit,
-    uint32 validatePaymentGasLimit,
-    uint32 executeGasLimit,
-    bytes callData,
-    bytes validatorData,
-    bytes extraData
-);
-
-/**
  * When the {interfaces/IAccount.execute} call succeeds but reports that the
  * attempted call reverted.
  *


### PR DESCRIPTION
### Description

Moved the `BoopSubmitted` event definition from `EventsAndErrors.sol` to `EntryPoint.sol` where it's actually used. The event documentation was updated to clarify that it's emitted by the EntryPoint contract for easier indexing of Boops and visibility on block explorers.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>