### PR TITLE
Refactor wagmi connection handling in setUserWithProvider

### DIFF
--- a/apps/iframe/src/actions/setUserWithProvider.ts
+++ b/apps/iframe/src/actions/setUserWithProvider.ts
@@ -2,16 +2,34 @@ import type { HappyUser } from "@happy.tech/wallet-common"
 import { AuthState } from "@happy.tech/wallet-common"
 import { getDefaultStore } from "jotai"
 import type { EIP1193Provider } from "viem"
+import { connectWagmi, disconnectWagmi } from "#src/wagmi/utils"
 import { authStateAtom } from "../state/authState"
 import { providerAtom } from "../state/provider"
 import { userAtom } from "../state/user"
 
 const store = getDefaultStore()
 
-export function setUserWithProvider(user: HappyUser | undefined, provider: EIP1193Provider | undefined) {
+/**
+ * Set the current user details along with the EIP 1193 Provider & auth state.
+ *
+ * If both user and provider are undefined, the intent is assumed to be a logout, and
+ * we will additionally disconnect the internal wagmi provider before clearing the state.
+ * If both are provided, the intent is assumed to be a login, and we will connect the internal wagmi
+ * provider once the jotai atoms state is set.
+ */
+export async function setUserWithProvider(user: undefined, provider: undefined): Promise<void>
+export async function setUserWithProvider(user: HappyUser, provider: EIP1193Provider): Promise<void>
+export async function setUserWithProvider(user: HappyUser | undefined, provider: EIP1193Provider | undefined) {
+    const isConnecting = Boolean(user && provider)
+
+    if (!isConnecting) await disconnectWagmi()
+
     store.set(providerAtom, provider)
     store.set(userAtom, user)
 
     // user auth state
-    store.set(authStateAtom, () => (user ? AuthState.Connected : AuthState.Disconnected))
+    store.set(authStateAtom, () => (isConnecting ? AuthState.Connected : AuthState.Disconnected))
+
+    // if wagmi wasn't previously successfully connected, this throws
+    if (isConnecting) await connectWagmi()
 }

--- a/apps/iframe/src/connections/GoogleConnector.ts
+++ b/apps/iframe/src/connections/GoogleConnector.ts
@@ -6,7 +6,6 @@ import { StorageKey, storage } from "#src/services/storage.ts"
 import { getChains } from "#src/state/chains.ts"
 import { grantPermissions } from "#src/state/permissions.ts"
 import { getAppURL } from "#src/utils/appURL.ts"
-import { connectWagmi, disconnectWagmi } from "#src/wagmi/utils"
 import { FirebaseConnector } from "./firebase"
 import { googleLogo } from "./firebase/logos"
 
@@ -60,24 +59,19 @@ export class GoogleConnector extends FirebaseConnector {
          * to repeat on the next page refresh.
          */
         if (storage.get(StorageKey.HappyUser)?.type !== WalletType.Social) return
-        try {
-            // if wagmi wasn't previously successfully connected, this throws
-            await disconnectWagmi()
-        } catch {}
-        setUserWithProvider(undefined, undefined)
+
+        await setUserWithProvider(undefined, undefined)
     }
 
     async onReconnect(user: HappyUser, provider: EIP1193Provider) {
         await this.addSupportedChains(provider)
-        setUserWithProvider(user, provider)
-        await connectWagmi()
+        await setUserWithProvider(user, provider)
     }
 
     async onConnect(user: HappyUser, provider: EIP1193Provider) {
         await this.addSupportedChains(provider)
-        setUserWithProvider(user, provider)
+        await setUserWithProvider(user, provider)
         grantPermissions(getAppURL(), "eth_accounts")
-        await connectWagmi()
     }
 
     private async addSupportedChains(provider: EIP1193Provider) {

--- a/apps/iframe/src/connections/InjectedConnector.ts
+++ b/apps/iframe/src/connections/InjectedConnector.ts
@@ -13,7 +13,6 @@ import { getCurrentChain } from "#src/state/chains"
 import { setInjectedProvider } from "#src/state/injectedProvider"
 import { walletID } from "#src/utils/appURL"
 import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
-import { connectWagmi, disconnectWagmi } from "#src/wagmi/utils"
 import { appMessageBus } from "../services/eventBus"
 import { StorageKey, storage } from "../services/storage"
 import { grantPermissions } from "../state/permissions"
@@ -71,23 +70,17 @@ export class InjectedConnector implements ConnectionProvider {
     }
 
     public async onConnect(user: HappyUser, provider: EIP1193Provider) {
-        setUserWithProvider(user, provider)
+        await setUserWithProvider(user, provider)
         grantPermissions(getAppURL(), "eth_accounts")
-        await connectWagmi()
     }
 
     public async onReconnect(user: HappyUser, provider: EIP1193Provider) {
-        setUserWithProvider(user, provider)
+        await setUserWithProvider(user, provider)
         grantPermissions(getAppURL(), "eth_accounts")
-        await connectWagmi()
     }
 
     public async onDisconnect() {
-        try {
-            // if wagmi wasn't previously successfully connected, this throws
-            await disconnectWagmi()
-        } catch {}
-        setUserWithProvider(undefined, undefined)
+        await setUserWithProvider(undefined, undefined)
     }
 
     public async connect(req: MsgsFromApp[Msgs.ConnectRequest]): Promise<MsgsFromWallet[Msgs.ConnectResponse]> {

--- a/apps/iframe/src/connections/InjectedProviderProxy.ts
+++ b/apps/iframe/src/connections/InjectedProviderProxy.ts
@@ -111,22 +111,15 @@ export class InjectedProviderProxy extends SafeEventEmitter {
             // Forward the event to the front end
             this.emit("accountsChanged", accounts)
 
-            // We need to dynamically import here to avoid any circular dependencies with iframeProvider
-            const { connectWagmi, disconnectWagmi } = await import("#src/wagmi/utils")
             const user = getUser()
             if (!accounts.length) {
-                try {
-                    // if wagmi wasn't previously successfully connected, this throws
-                    await disconnectWagmi()
-                } catch {}
                 // Logout from the wallet when the user disconnects the injected wallet from the standalone wallet.
-                setUserWithProvider(undefined, undefined)
+                await setUserWithProvider(undefined, undefined)
             } else if (user) {
                 const [address] = accounts
                 const _user = await createHappyUserFromWallet(user.provider, address)
-                setUserWithProvider(_user, InjectedProviderProxy.getInstance() as EIP1193Provider)
+                await setUserWithProvider(_user, InjectedProviderProxy.getInstance() as EIP1193Provider)
                 grantPermissions(getAppURL(), "eth_accounts")
-                await connectWagmi()
             }
         })
     }
@@ -141,23 +134,14 @@ export class InjectedProviderProxy extends SafeEventEmitter {
         // handle any required internal changes
         switch (req.payload.event) {
             case "accountsChanged": {
-                // We need to dynamically import here to avoid any circular dependencies with iframeProvider
-                const { connectWagmi, disconnectWagmi } = await import("#src/wagmi/utils")
                 const user = getUser()
                 if (Array.isArray(req.payload.params) && !req.payload.params.length) {
-                    // on disconnect, logout. alternatively could revoke permissions, but not much
-                    // point in that for injected wallets
-                    try {
-                        // if wagmi wasn't previously successfully connected, this throws
-                        await disconnectWagmi()
-                    } catch {}
-                    setUserWithProvider(undefined, undefined)
+                    await setUserWithProvider(undefined, undefined)
                 } else if (Array.isArray(req.payload.params) && user) {
                     const [address] = req.payload.params
                     const _user = await createHappyUserFromWallet(user.provider, address)
-                    setUserWithProvider(_user, InjectedProviderProxy.getInstance() as EIP1193Provider)
+                    await setUserWithProvider(_user, InjectedProviderProxy.getInstance() as EIP1193Provider)
                     grantPermissions(getAppURL(), "eth_accounts")
-                    await connectWagmi()
                 }
             }
         }

--- a/apps/iframe/src/wagmi/config.ts
+++ b/apps/iframe/src/wagmi/config.ts
@@ -3,7 +3,6 @@ import { convertToViemChain, chains as defaultChains } from "@happy.tech/wallet-
 import { createConfig } from "@wagmi/core"
 import { type Chain, createClient, custom } from "viem"
 import { getCurrentChain } from "../state/chains"
-import { happyConnector } from "./connector"
 import { iframeProvider } from "./provider"
 
 // cf. https://wagmi.sh/react/typescript#declaration-merging
@@ -13,15 +12,18 @@ declare module "wagmi" {
     }
 }
 
-const currentChain: Chain = convertToViemChain(getCurrentChain())
-const chains = [currentChain, ...defaultChains].filter(onlyUnique)
+const currentChain = convertToViemChain(getCurrentChain())
+const chains = [currentChain, ...defaultChains].filter(onlyUnique) as [Chain, ...Chain[]]
 
 /**
- * Create Wagmi Config with custom connector to support HappyChain Sepolia.
+ * Create Wagmi Config with custom client for our internal iframeProvider.
+ *
+ * note: do not set the connector here as it will result in a circular dependency
+ * with the InjectedProviderProxy. Instead we pass the connector explicitly to the connect
+ * function
  */
 export const config = createConfig({
-    chains: chains as unknown as readonly [Chain, ...Chain[]],
+    chains,
     multiInjectedProviderDiscovery: false,
     client: ({ chain }) => createClient({ chain, transport: custom(iframeProvider) }),
-    connectors: [happyConnector],
 })

--- a/apps/iframe/src/wagmi/utils.ts
+++ b/apps/iframe/src/wagmi/utils.ts
@@ -2,10 +2,19 @@ import { connect, disconnect } from "@wagmi/core"
 import { config } from "./config"
 import { happyConnector } from "./connector"
 
+/**
+ * Connects wagmi to the iframe provider.
+ */
 export async function connectWagmi() {
     return await connect(config, { connector: happyConnector })
 }
 
+/**
+ * Disconnects wagmi from the iframe provider.
+ */
 export async function disconnectWagmi() {
-    return await disconnect(config)
+    try {
+        // if wagmi was not previously connected, this will throw an error
+        return await disconnect(config)
+    } catch {}
 }


### PR DESCRIPTION
### Description

This PR refactors the user authentication flow to better handle wagmi connections. The main changes:

- Enhances `setUserWithProvider` to handle wagmi connections and disconnections internally, making it the single source of truth for user authentication state
- Adds proper TypeScript function overloads to `setUserWithProvider` to enforce correct parameter combinations
- Removes redundant wagmi connection/disconnection calls from various connector implementations
- Improves error handling during wagmi disconnection
- Adds documentation to clarify the authentication flow
- Reorganizes wagmi client configuration for better maintainability

These changes simplify the authentication flow by centralizing the wagmi connection logic within `setUserWithProvider`, reducing code duplication and potential inconsistencies across different connector implementations.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>