### PR TITLE
Rename iframe references to wallet for consistency

### DIFF
--- a/apps/iframe/src/components/ConnectModal.tsx
+++ b/apps/iframe/src/components/ConnectModal.tsx
@@ -5,7 +5,7 @@ import { useMutation } from "@tanstack/react-query"
 import { cx } from "class-variance-authority"
 import { useCallback, useEffect, useState } from "react"
 import { FirebaseErrorCode, isFirebaseError } from "#src/connections/firebase/errors"
-import { iframeID } from "#src/utils/appURL"
+import { walletID } from "#src/utils/appURL"
 import { patchTimeoutOff, signalClosed } from "#src/utils/walletState"
 import { useConnectionProviders } from "../connections/initialize"
 import { appMessageBus } from "../services/eventBus"
@@ -77,7 +77,7 @@ const ConnectContent = () => {
             // if no dapp-request exists here, we will initiate a new one
             const connectRequest = clientConnectionRequest ?? {
                 key: createUUID(),
-                windowId: iframeID(),
+                windowId: walletID(),
                 error: null,
                 payload: { method: "eth_requestAccounts" },
             }

--- a/apps/iframe/src/components/interface/permissions/useAppsWithPermissions.ts
+++ b/apps/iframe/src/components/interface/permissions/useAppsWithPermissions.ts
@@ -2,14 +2,14 @@ import { entries } from "@happy.tech/common"
 import { useAtomValue } from "jotai"
 import { useAccount } from "wagmi"
 import { type AppPermissions, permissionsMapAtom } from "#src/state/permissions"
-import { type AppURL, isIframe } from "#src/utils/appURL"
+import { type AppURL, isWallet } from "#src/utils/appURL"
 
 function useAppsWithPermissions(): [AppURL, AppPermissions][] {
     const permissionsMap = useAtomValue(permissionsMapAtom)
     const account = useAccount()
 
     return entries(permissionsMap[account?.address ?? "0x0"] ?? {}) //
-        .filter(([app]) => !isIframe(app))
+        .filter(([app]) => !isWallet(app))
 }
 
 export { useAppsWithPermissions }

--- a/apps/iframe/src/connections/InjectedProviderProxy.ts
+++ b/apps/iframe/src/connections/InjectedProviderProxy.ts
@@ -15,7 +15,7 @@ import { happyProviderBus } from "#src/services/eventBus.ts"
 import { getInjectedProvider } from "#src/state/injectedProvider.ts"
 import { grantPermissions } from "#src/state/permissions.ts"
 import { getUser } from "#src/state/user.ts"
-import { getAppURL, iframeID, isStandaloneIframe } from "#src/utils/appURL.ts"
+import { getAppURL, isStandaloneWallet, walletID } from "#src/utils/appURL.ts"
 import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet.ts"
 import { iframeProvider } from "#src/wagmi/provider.ts"
 
@@ -47,7 +47,7 @@ export class InjectedProviderProxy extends SafeEventEmitter {
 
     private inFlight = new Map()
 
-    private isStandalone = isStandaloneIframe()
+    private isStandalone = isStandaloneWallet()
 
     private constructor() {
         super()
@@ -63,7 +63,7 @@ export class InjectedProviderProxy extends SafeEventEmitter {
     async request(args: EIP1193RequestParameters) {
         const req = {
             key: createUUID(),
-            windowId: iframeID(),
+            windowId: walletID(),
             error: null,
             payload: args,
         }
@@ -95,7 +95,7 @@ export class InjectedProviderProxy extends SafeEventEmitter {
     public handleRequestResolution(
         resp: ProviderEventError<SerializedRpcError> | ProviderEventPayload<EIP1193RequestResult>,
     ): void {
-        const iframeRequest = resp.windowId === iframeID()
+        const iframeRequest = resp.windowId === walletID()
         const pending = this.inFlight.get(resp.key)
         if (!pending && iframeRequest) iframeProvider.handleRequestResolution(resp)
         else if (pending?.reject && resp.error) pending.reject(standardizeRpcError(resp.error))

--- a/apps/iframe/src/connections/firebase/services/FirebaseConnector.ts
+++ b/apps/iframe/src/connections/firebase/services/FirebaseConnector.ts
@@ -4,7 +4,7 @@ import {
     type HappyUser,
     type Msgs,
     type MsgsFromApp,
-    type MsgsFromIframe,
+    type MsgsFromWallet,
     WalletType,
 } from "@happy.tech/wallet-common"
 import type { JWTLoginParams } from "@web3auth/mpc-core-kit"
@@ -61,7 +61,7 @@ export abstract class FirebaseConnector implements ConnectionProvider {
      * It gets set to false when onAuthChange response after the login attempt
      */
     private instanceIsConnecting = false
-    public async connect(request: MsgsFromApp[Msgs.ConnectRequest]): Promise<MsgsFromIframe[Msgs.ConnectResponse]> {
+    public async connect(request: MsgsFromApp[Msgs.ConnectRequest]): Promise<MsgsFromWallet[Msgs.ConnectResponse]> {
         this.instanceIsConnecting = true
         await setFirebaseAuthState(FirebaseAuthState.Connecting)
         try {

--- a/apps/iframe/src/connections/initialize.ts
+++ b/apps/iframe/src/connections/initialize.ts
@@ -4,7 +4,7 @@ import { atom, getDefaultStore, useAtomValue } from "jotai"
 import { createStore } from "mipd"
 import { useMemo } from "react"
 import { appMessageBus } from "#src/services/eventBus.ts"
-import { isStandaloneIframe } from "#src/utils/appURL.ts"
+import { isStandaloneWallet } from "#src/utils/appURL.ts"
 import { userAtom } from "../state/user"
 import { GoogleConnector } from "./GoogleConnector"
 import { InjectedConnector } from "./InjectedConnector"
@@ -39,7 +39,7 @@ addProvider(new GoogleConnector())
  * if the wallet is embedded, then there are situations where these events, as well as injected
  * wallest such as window.ethereum are shielded from us, preventing us from detecting them.
  */
-if (isStandaloneIframe()) {
+if (isStandaloneWallet()) {
     const mipdStore = createStore()
 
     // load all initialized providers
@@ -70,8 +70,9 @@ if (isStandaloneIframe()) {
         )
     }
 } else {
-    // Instead of listening to the EIP-6963 events inside the iframe, the app listens to them and forwards them
-    // to us, as not every wallet will inject itself into iframes.
+    // Instead of listening to the EIP-6963 events inside the happy-wallet, the app listens to them
+    // and forwards them here, as not every injected wallet will allow itself to be
+    // injected into iframes.
     appMessageBus.on(Msgs.AnnounceInjectedProvider, (provider) => {
         if (provider.info.rdns === happyProviderInfo.rdns) return
         addProvider(

--- a/apps/iframe/src/requests/handlers/rejected.ts
+++ b/apps/iframe/src/requests/handlers/rejected.ts
@@ -8,7 +8,7 @@ import {
 import { InjectedProviderProxy } from "#src/connections/InjectedProviderProxy.ts"
 import { happyProviderBus } from "#src/services/eventBus"
 import { getUser } from "#src/state/user.ts"
-import { appForSourceID, isIframe } from "#src/utils/appURL"
+import { appForSourceID, isWallet } from "#src/utils/appURL"
 import { iframeProvider } from "#src/wagmi/provider"
 
 /**
@@ -32,12 +32,12 @@ export async function handleRejectedRequest(data: PopupMsgs[Msgs.PopupReject]): 
         return
     }
 
-    const _isIframe = isIframe(app)
+    const _isWallet = isWallet(app)
     const _isInjected = getUser()?.type === WalletType.Injected
 
-    if (_isIframe && _isInjected) {
+    if (_isWallet && _isInjected) {
         InjectedProviderProxy.getInstance().handleRequestResolution(response)
-    } else if (_isIframe) {
+    } else if (_isWallet) {
         iframeProvider.handleRequestResolution(response)
     } else {
         void happyProviderBus.emit(Msgs.RequestResponse, response)

--- a/apps/iframe/src/requests/tests/eth_requestAccounts.same_origin.spec.ts
+++ b/apps/iframe/src/requests/tests/eth_requestAccounts.same_origin.spec.ts
@@ -9,7 +9,7 @@ import { setUser } from "#src/state/user"
 import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 import { dispatchedPermissionlessRequest } from "../handlers/permissionless"
 
-const { appURL, iframeID, appURLMock } = await vi //
+const { appURL, walletID, appURLMock } = await vi //
     .hoisted(async () => await import("#src/testing/same_origin.mocks"))
 
 vi.mock(import("#src/utils/appURL"), appURLMock)
@@ -25,7 +25,7 @@ describe("#publicClient #eth_requestAccounts #same_origin", () => {
 
         test("skips eth_requestAccounts permissions when no user", async () => {
             expect(getAllPermissions(appURL).length).toBe(0)
-            const request = makePayload(iframeID, { method: "eth_requestAccounts" })
+            const request = makePayload(walletID, { method: "eth_requestAccounts" })
             await expect(dispatchedPermissionlessRequest(request)).rejects.toThrow(EIP1193UnauthorizedError)
         })
     })
@@ -42,7 +42,7 @@ describe("#publicClient #eth_requestAccounts #same_origin", () => {
 
         test("returns connected user address when requested", async () => {
             expect(getAllPermissions(appURL).length).toBe(1)
-            const request = makePayload(iframeID, { method: "eth_requestAccounts" })
+            const request = makePayload(walletID, { method: "eth_requestAccounts" })
             const response = await dispatchedPermissionlessRequest(request)
             expect(response).toStrictEqual([user.address])
             expect(getAllPermissions(appURL).length).toBe(1)
@@ -50,7 +50,7 @@ describe("#publicClient #eth_requestAccounts #same_origin", () => {
 
         test("does not add permissions", async () => {
             expect(getAllPermissions(appURL).length).toBe(1)
-            const request = makePayload(iframeID, { method: "eth_requestAccounts" })
+            const request = makePayload(walletID, { method: "eth_requestAccounts" })
             await dispatchedPermissionlessRequest(request)
             await dispatchedPermissionlessRequest(request)
             await dispatchedPermissionlessRequest(request)

--- a/apps/iframe/src/requests/tests/wallet_requestPermissions.no_conf.same_origin.spec.ts
+++ b/apps/iframe/src/requests/tests/wallet_requestPermissions.no_conf.same_origin.spec.ts
@@ -9,7 +9,7 @@ import { clearPermissions, getAllPermissions } from "#src/state/permissions.ts"
 import { setUser } from "#src/state/user"
 import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 
-const { appURL, iframeID, appURLMock } = await vi //
+const { appURL, walletID, appURLMock } = await vi //
     .hoisted(async () => await import("#src/testing/same_origin.mocks"))
 
 vi.mock(import("#src/utils/appURL"), appURLMock)
@@ -25,7 +25,7 @@ describe("#publicClient #wallet_requestPermissions #same_origin", () => {
 
         test("skips wallet_requestPermissions permissions when no user", async () => {
             expect(getAllPermissions(appURL).length).toBe(0)
-            const request = makePayload(iframeID, {
+            const request = makePayload(walletID, {
                 method: "wallet_requestPermissions",
                 params: [{ eth_accounts: {} }],
             })
@@ -44,7 +44,7 @@ describe("#publicClient #wallet_requestPermissions #same_origin", () => {
 
         test("does not add permissions", async () => {
             expect(getAllPermissions(appURL).length).toBe(1)
-            const request = makePayload(iframeID, {
+            const request = makePayload(walletID, {
                 method: "wallet_requestPermissions",
                 params: [{ eth_accounts: {} }],
             })

--- a/apps/iframe/src/requests/tests/wallet_requestPermissions.user_conf.cross_origin.spec.ts
+++ b/apps/iframe/src/requests/tests/wallet_requestPermissions.user_conf.cross_origin.spec.ts
@@ -8,7 +8,7 @@ import { clearPermissions, getAllPermissions } from "#src/state/permissions.ts"
 import { setUser } from "#src/state/user"
 import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 
-const { appURL, iframeURL, parentID, appURLMock } = await vi //
+const { appURL, walletURL, parentID, appURLMock } = await vi //
     .hoisted(async () => await import("#src/testing/cross_origin.mocks"))
 
 vi.mock(import("#src/utils/appURL"), appURLMock)
@@ -25,11 +25,11 @@ describe("#walletClient #wallet_requestPermissions #cross_origin", () => {
 
     test("adds eth_account permissions (no caveats)", async () => {
         expect(getAllPermissions(appURL).length).toBe(0)
-        expect(getAllPermissions(iframeURL).length).toBe(1)
+        expect(getAllPermissions(walletURL).length).toBe(1)
         const request = makePayload(parentID, { method: "wallet_requestPermissions", params: [{ eth_accounts: {} }] })
         const response = await dispatchApprovedRequest(request)
         expect(getAllPermissions(appURL).length).toBe(1)
-        expect(getAllPermissions(iframeURL).length).toBe(1)
+        expect(getAllPermissions(walletURL).length).toBe(1)
         expect(getAllPermissions(appURL)).toStrictEqual(response)
         expect(response).toStrictEqual([
             {
@@ -74,13 +74,13 @@ describe("#walletClient #wallet_requestPermissions #cross_origin", () => {
 
     test("only adds permissions once", async () => {
         expect(getAllPermissions(appURL).length).toBe(0)
-        expect(getAllPermissions(iframeURL).length).toBe(1)
+        expect(getAllPermissions(walletURL).length).toBe(1)
         const request = makePayload(parentID, { method: "wallet_requestPermissions", params: [{ eth_accounts: {} }] })
         await dispatchApprovedRequest(request)
         await dispatchApprovedRequest(request)
         await dispatchApprovedRequest(request)
         await dispatchApprovedRequest(request)
         expect(getAllPermissions(appURL).length).toBe(1)
-        expect(getAllPermissions(iframeURL).length).toBe(1)
+        expect(getAllPermissions(walletURL).length).toBe(1)
     })
 })

--- a/apps/iframe/src/requests/tests/wallet_requestPermissions.user_conf.same_origin.spec.ts
+++ b/apps/iframe/src/requests/tests/wallet_requestPermissions.user_conf.same_origin.spec.ts
@@ -9,7 +9,7 @@ import { clearPermissions, getAllPermissions } from "#src/state/permissions.ts"
 import { setUser } from "#src/state/user"
 import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 
-const { appURL, iframeID, appURLMock } = await vi //
+const { appURL, walletID, appURLMock } = await vi //
     .hoisted(async () => await import("#src/testing/same_origin.mocks"))
 
 vi.mock(import("#src/utils/appURL"), appURLMock)
@@ -26,7 +26,7 @@ describe("#walletClient #wallet_requestPermissions #same_origin", () => {
 
     test("adds eth_account permissions (no caveats)", async () => {
         expect(getAllPermissions(appURL).length).toBe(1)
-        const request = makePayload(iframeID, {
+        const request = makePayload(walletID, {
             method: "wallet_requestPermissions",
             params: [{ eth_accounts: {} }],
         })
@@ -45,7 +45,7 @@ describe("#walletClient #wallet_requestPermissions #same_origin", () => {
 
     test("adds eth_account permissions (with caveats)", async () => {
         expect(getAllPermissions(appURL).length).toBe(1)
-        const request = makePayload(iframeID, {
+        const request = makePayload(walletID, {
             method: "wallet_requestPermissions",
             params: [
                 {
@@ -75,7 +75,7 @@ describe("#walletClient #wallet_requestPermissions #same_origin", () => {
 
     test("only adds permissions once", async () => {
         expect(getAllPermissions(appURL).length).toBe(1)
-        const request = makePayload(iframeID, { method: "wallet_requestPermissions", params: [{ eth_accounts: {} }] })
+        const request = makePayload(walletID, { method: "wallet_requestPermissions", params: [{ eth_accounts: {} }] })
         await dispatchApprovedRequest(request)
         await dispatchApprovedRequest(request)
         await dispatchApprovedRequest(request)

--- a/apps/iframe/src/requests/tests/wallet_watchAsset.spec.ts
+++ b/apps/iframe/src/requests/tests/wallet_watchAsset.spec.ts
@@ -8,7 +8,7 @@ import { getWatchedAssets } from "#src/state/watchedAssets.ts"
 import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 import { dispatchApprovedRequest } from "../handlers/approved"
 
-const { iframeID, appURLMock } = await vi //
+const { walletID, appURLMock } = await vi //
     .hoisted(async () => await import("#src/testing/cross_origin.mocks"))
 
 vi.mock(import("#src/utils/appURL"), appURLMock)
@@ -24,7 +24,7 @@ describe("walletClient wallet_watchAsset", () => {
 
     test("adds token", async () => {
         expect(Object.keys(getWatchedAssets()).length).toBe(0)
-        const request = makePayload(iframeID, {
+        const request = makePayload(walletID, {
             method: "wallet_watchAsset",
             params: {
                 type: "ERC20",

--- a/apps/iframe/src/requests/utils/sendResponse.ts
+++ b/apps/iframe/src/requests/utils/sendResponse.ts
@@ -13,7 +13,7 @@ import { InjectedProviderProxy } from "#src/connections/InjectedProviderProxy.ts
 import { happyProviderBus } from "#src/services/eventBus"
 import { getCurrentChain } from "#src/state/chains"
 import { getUser } from "#src/state/user.ts"
-import { appForSourceID, isIframe } from "#src/utils/appURL"
+import { appForSourceID, isWallet } from "#src/utils/appURL"
 import { reqLogger } from "#src/utils/logger"
 import { iframeProvider } from "#src/wagmi/provider"
 
@@ -52,12 +52,12 @@ export async function sendResponse<Request extends ProviderEventPayload<Approved
             payload: payload ?? undefined,
         }
 
-        const _isIframe = isIframe(app)
+        const _isWallet = isWallet(app)
         const _isInjected = getUser()?.type === WalletType.Injected
 
-        if (_isIframe && _isInjected) {
+        if (_isWallet && _isInjected) {
             InjectedProviderProxy.getInstance().handleRequestResolution(response)
-        } else if (_isIframe) {
+        } else if (_isWallet) {
             iframeProvider.handleRequestResolution(response)
         } else {
             void happyProviderBus.emit(Msgs.RequestResponse, response)
@@ -80,12 +80,12 @@ export async function sendResponse<Request extends ProviderEventPayload<Approved
             payload: null,
         }
 
-        const isIframe_ = isIframe(app)
-        const isInjected_ = getUser()?.type === WalletType.Injected
+        const _isWallet = isWallet(app)
+        const _isInjected = getUser()?.type === WalletType.Injected
 
-        if (isIframe_ && isInjected_) {
+        if (_isWallet && _isInjected) {
             InjectedProviderProxy.getInstance().handleRequestResolution(response)
-        } else if (isIframe_) {
+        } else if (_isWallet) {
             iframeProvider.handleRequestResolution(response)
         } else {
             void happyProviderBus.emit(Msgs.RequestResponse, response)

--- a/apps/iframe/src/routes/embed.lazy.tsx
+++ b/apps/iframe/src/routes/embed.lazy.tsx
@@ -52,7 +52,7 @@ function Embed() {
 
         // If we initialized before the above listener is created, then
         // RequestWalletDisplay calls will be silently lost
-        void appMessageBus.emit(Msgs.IframeInit, true)
+        void appMessageBus.emit(Msgs.WalletInit, true)
         return unsubscribe
     }, [navigate, setSecondaryMenuVisibility, setDialogLogoutVisibility])
 

--- a/apps/iframe/src/services/eventBus.ts
+++ b/apps/iframe/src/services/eventBus.ts
@@ -1,6 +1,6 @@
-import { EventBus, EventBusMode, type ProviderMsgsFromIframe } from "@happy.tech/wallet-common"
+import { EventBus, EventBusMode, type ProviderMsgsFromWallet } from "@happy.tech/wallet-common"
 import type { ProviderMsgsFromApp } from "@happy.tech/wallet-common"
-import type { MsgsFromApp, MsgsFromIframe } from "@happy.tech/wallet-common"
+import type { MsgsFromApp, MsgsFromWallet } from "@happy.tech/wallet-common"
 
 /**
  * Iframe side of the app <> iframe provider bus.
@@ -11,7 +11,7 @@ import type { MsgsFromApp, MsgsFromIframe } from "@happy.tech/wallet-common"
  *
  * This side is created first (MessageChannel port1) and will wait for the app side to connect.
  */
-export const happyProviderBus = new EventBus<ProviderMsgsFromApp, ProviderMsgsFromIframe>({
+export const happyProviderBus = new EventBus<ProviderMsgsFromApp, ProviderMsgsFromWallet>({
     target: window.parent,
     mode: EventBusMode.IframePort,
     scope: "happy-chain-eip1193-provider",
@@ -22,7 +22,7 @@ export const happyProviderBus = new EventBus<ProviderMsgsFromApp, ProviderMsgsFr
  *
  * This will be used to receive UI requests from the app, send auth updates, etc.
  */
-export const appMessageBus = new EventBus<MsgsFromApp, MsgsFromIframe>({
+export const appMessageBus = new EventBus<MsgsFromApp, MsgsFromWallet>({
     target: window.parent,
     mode: EventBusMode.IframePort,
     scope: "happy-chain-dapp-bus",

--- a/apps/iframe/src/state/permissions.spec.ts
+++ b/apps/iframe/src/state/permissions.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "#src/state/permissions.ts"
 import { setUser } from "../state/user"
 
-const { appURL, iframeURL, appURLMock } = await vi //
+const { appURL, walletURL, appURLMock } = await vi //
     .hoisted(async () => await import("#src/testing/cross_origin.mocks"))
 
 vi.mock(import("#src/utils/appURL"), appURLMock)
@@ -140,24 +140,24 @@ describe("PermissionsService", () => {
                     const initialState = hasPermissions(appURL, "eth_accounts")
                     expect(initialState).toBe(false)
 
-                    grantPermissions(iframeURL, "eth_accounts")
+                    grantPermissions(walletURL, "eth_accounts")
 
                     const finalState = hasPermissions(appURL, "eth_accounts")
                     expect(finalState).toBe(false)
                 })
 
                 it("should not change state if eth_accounts permission is already granted", () => {
-                    grantPermissions(iframeURL, "eth_accounts")
+                    grantPermissions(walletURL, "eth_accounts")
                     const initialStateA = hasPermissions(appURL, "eth_accounts")
                     expect(initialStateA).toBe(false)
-                    const initialStateB = hasPermissions(iframeURL, "eth_accounts")
+                    const initialStateB = hasPermissions(walletURL, "eth_accounts")
                     expect(initialStateB).toBe(true)
 
-                    grantPermissions(iframeURL, "eth_accounts")
+                    grantPermissions(walletURL, "eth_accounts")
 
                     const finalStateA = hasPermissions(appURL, "eth_accounts")
                     expect(finalStateA).toBe(false)
-                    const finalStateB = hasPermissions(iframeURL, "eth_accounts")
+                    const finalStateB = hasPermissions(walletURL, "eth_accounts")
                     expect(finalStateB).toBe(true)
                 })
             })
@@ -170,13 +170,13 @@ describe("PermissionsService", () => {
                 it("should not grant eth_accounts permission", () => {
                     const initialStateA = hasPermissions(appURL, "eth_accounts")
                     expect(initialStateA).toBe(false)
-                    const initialStateB = hasPermissions(iframeURL, "eth_accounts")
+                    const initialStateB = hasPermissions(walletURL, "eth_accounts")
                     expect(initialStateB).toBe(false)
                     grantPermissions(appURL, "eth_accounts")
 
                     const finalStateA = hasPermissions(appURL, "eth_accounts")
                     expect(finalStateA).toBe(false)
-                    const finalStateB = hasPermissions(iframeURL, "eth_accounts")
+                    const finalStateB = hasPermissions(walletURL, "eth_accounts")
                     expect(finalStateB).toBe(false)
                 })
             })
@@ -241,7 +241,7 @@ describe("PermissionsService", () => {
                     const initialState = hasPermissions(appURL, "eth_accounts")
                     expect(initialState).toBe(true)
 
-                    revokePermissions(iframeURL, "eth_accounts")
+                    revokePermissions(walletURL, "eth_accounts")
 
                     const finalState = hasPermissions(appURL, "eth_accounts")
                     expect(finalState).toBe(true)
@@ -330,29 +330,29 @@ describe("PermissionsService", () => {
                 })
 
                 it("returns eth_accounts to iframe when no permissions have been granted", () => {
-                    expect(getPermissions(iframeURL, "eth_accounts").length).toBe(1)
+                    expect(getPermissions(walletURL, "eth_accounts").length).toBe(1)
                 })
 
                 it("returns all permissions granted to app (without caveats)", () => {
                     grantPermissions(appURL, "test_permission_app")
-                    grantPermissions(iframeURL, "test_permission_iframe")
+                    grantPermissions(walletURL, "test_permission_iframe")
 
                     expect(getPermissions(appURL, "test_permission_app").length).toBe(1)
                     expect(getPermissions(appURL, "test_permission_iframe").length).toBe(0)
 
-                    expect(getPermissions(iframeURL, "test_permission_app").length).toBe(0)
-                    expect(getPermissions(iframeURL, "test_permission_iframe").length).toBe(1)
+                    expect(getPermissions(walletURL, "test_permission_app").length).toBe(0)
+                    expect(getPermissions(walletURL, "test_permission_iframe").length).toBe(1)
                 })
 
                 it("returns all permissions granted to app (all caveats)", () => {
                     expect(getAllPermissions(appURL).length).toBe(0)
 
                     grantPermissions(appURL, { [Permissions.SessionKey]: { target: "0x1234" } })
-                    grantPermissions(iframeURL, { [Permissions.SessionKey]: { target: "0x4567" } })
+                    grantPermissions(walletURL, { [Permissions.SessionKey]: { target: "0x4567" } })
 
                     expect(getPermissions(appURL, Permissions.SessionKey).length).toBe(1)
                     expect(getPermissions(appURL, Permissions.SessionKey)[0].caveats.length).toBe(1)
-                    expect(getPermissions(iframeURL, Permissions.SessionKey)[0].caveats.length).toBe(1)
+                    expect(getPermissions(walletURL, Permissions.SessionKey)[0].caveats.length).toBe(1)
                 })
             })
 
@@ -364,7 +364,7 @@ describe("PermissionsService", () => {
 
                 it("returns empty array when no permissions have been granted", () => {
                     expect(getPermissions(appURL, "eth_accounts").length).toBe(0)
-                    expect(getPermissions(iframeURL, "eth_accounts").length).toBe(0)
+                    expect(getPermissions(walletURL, "eth_accounts").length).toBe(0)
                 })
             })
         })
@@ -413,8 +413,8 @@ describe("PermissionsService", () => {
                     grantPermissions(appURL, "eth_accounts")
                     grantPermissions(appURL, "test_permission_app_1")
                     grantPermissions(appURL, "test_permission_app_2")
-                    grantPermissions(iframeURL, "test_permission_iframe")
-                    expect(getAllPermissions(iframeURL).length).toBe(2)
+                    grantPermissions(walletURL, "test_permission_iframe")
+                    expect(getAllPermissions(walletURL).length).toBe(2)
                 })
             })
         })

--- a/apps/iframe/src/state/permissions.ts
+++ b/apps/iframe/src/state/permissions.ts
@@ -5,7 +5,7 @@ import { type Atom, atom, getDefaultStore } from "jotai"
 import { atomFamily, atomWithStorage, createJSONStorage } from "jotai/utils"
 import { Permissions } from "#src/constants/permissions"
 import { StorageKey } from "../services/storage"
-import { type AppURL, getAppURL, getIframeURL, isApp, isStandaloneIframe } from "../utils/appURL"
+import { type AppURL, getAppURL, getWalletURL, isApp, isStandaloneWallet } from "../utils/appURL"
 import { checkIfCaveatsMatch } from "../utils/checkIfCaveatsMatch"
 import { emitUserUpdate } from "../utils/emitUserUpdate"
 import { revokedSessionKeys } from "./interfaceState"
@@ -148,7 +148,7 @@ export function getAppPermissions(app: AppURL): AppPermissions {
     // Permissions don't exist, create them.
 
     const baseAppPermissions: AppPermissions =
-        app === getIframeURL()
+        app === getWalletURL()
             ? {
                   // The iframe is always granted the `eth_accounts` permission.
                   eth_accounts: {
@@ -322,7 +322,7 @@ export function grantPermissions(app: AppURL, permissionRequest: PermissionsRequ
         }
 
         // Accounts permission granted, which lets the app access the user object.
-        if (name === "eth_accounts" && isApp(app) && !isStandaloneIframe()) {
+        if (name === "eth_accounts" && isApp(app) && !isStandaloneWallet()) {
             emitUserUpdate(getUser())
         }
 

--- a/apps/iframe/src/testing/cross_origin.mocks.ts
+++ b/apps/iframe/src/testing/cross_origin.mocks.ts
@@ -2,20 +2,21 @@ import { type UUID, createUUID } from "@happy.tech/common"
 import type { AppURL } from "#src/utils/appURL"
 
 export const appURL = "http://localhost:1234" as AppURL
-export const iframeURL = "http://localhost:4321" as AppURL
+export const walletURL = "http://localhost:4321" as AppURL
 export const parentID = createUUID()
-export const iframeID = createUUID()
+export const walletID = createUUID()
 
 export const appURLMock = async () => ({
     getAppURL: () => appURL,
-    getIframeURL: () => iframeURL,
-    iframeID: () => iframeID,
+    getWalletURL: () => walletURL,
+    walletID: () => walletID,
     isApp: (app: AppURL) => app === appURL,
-    isIframe: (app: AppURL) => app === iframeURL,
-    isStandaloneIframe: () => false,
-    appForSourceID(sourceId: UUID): AppURL | undefined {
-        if (sourceId === parentID) return appURL
-        if (sourceId === iframeID) return iframeURL
+    isWallet: (app: AppURL) => app === walletURL,
+    isStandaloneWallet: () => false,
+    isEmbeddedWallet: () => true,
+    appForSourceID(sourceID: UUID): AppURL | undefined {
+        if (sourceID === parentID) return appURL
+        if (sourceID === walletID) return walletURL
         return undefined
     },
 })

--- a/apps/iframe/src/testing/same_origin.mocks.ts
+++ b/apps/iframe/src/testing/same_origin.mocks.ts
@@ -2,17 +2,18 @@ import { type UUID, createUUID } from "@happy.tech/common"
 import type { AppURL } from "#src/utils/appURL"
 
 export const appURL = "http://localhost:4321" as AppURL
-export const iframeID = createUUID()
+export const walletID = createUUID()
 
 export const appURLMock = async () => ({
     getAppURL: () => appURL,
-    getIframeURL: () => appURL,
-    iframeID: () => iframeID,
+    getWalletURL: () => appURL,
+    walletID: () => walletID,
     isApp: (_app: AppURL) => true,
-    isIframe: (_app: AppURL) => true,
-    isStandaloneIframe: () => true,
+    isWallet: (_app: AppURL) => true,
+    isStandaloneWallet: () => true,
+    isEmbeddedWallet: () => false,
     appForSourceID(sourceId: UUID): AppURL | undefined {
-        if (sourceId === iframeID) return appURL
+        if (sourceId === walletID) return appURL
         return undefined
     },
 })

--- a/apps/iframe/src/utils/emitUserUpdate.ts
+++ b/apps/iframe/src/utils/emitUserUpdate.ts
@@ -2,7 +2,7 @@ import { debounce } from "@happy.tech/common"
 import { type HappyUser, Msgs } from "@happy.tech/wallet-common"
 import { hasPermissions } from "#src/state/permissions.ts"
 import { appMessageBus, happyProviderBus } from "../services/eventBus"
-import { getAppURL, isStandaloneIframe } from "./appURL"
+import { getAppURL, isStandaloneWallet } from "./appURL"
 
 /**
  * Emits user info to the connected app after checking permissions.
@@ -15,7 +15,7 @@ import { getAppURL, isStandaloneIframe } from "./appURL"
  * @emits {@link Msgs.ProviderEvent} (optional)
  */
 export const emitUserUpdate = debounce((user?: HappyUser) => {
-    if (isStandaloneIframe()) return
+    if (isStandaloneWallet()) return
 
     const hasPerms = user ? hasPermissions(getAppURL(), "eth_accounts") : false
     const _user = hasPerms ? user : undefined

--- a/apps/iframe/src/wagmi/provider.ts
+++ b/apps/iframe/src/wagmi/provider.ts
@@ -12,7 +12,7 @@ import { addBanner } from "#src/state/banner.ts"
 import { getUser } from "#src/state/user.ts"
 import { handleInjectedRequest, handlePermissionlessRequest } from "../requests"
 import { getAuthState } from "../state/authState"
-import { getIframeURL, iframeID } from "../utils/appURL"
+import { getWalletURL, walletID } from "../utils/appURL"
 import { checkIfRequestRequiresConfirmation } from "../utils/checkIfRequestRequiresConfirmation"
 
 /**
@@ -26,10 +26,10 @@ import { checkIfRequestRequiresConfirmation } from "../utils/checkIfRequestRequi
  * The provider routes the call to our logic in the `requests` directory.
  */
 export class IframeProvider extends BasePopupProvider {
-    protected popupBaseUrl = getIframeURL()
+    protected popupBaseUrl = getWalletURL()
 
     constructor() {
-        super(iframeID())
+        super(walletID())
     }
 
     protected onPopupBlocked() {
@@ -45,7 +45,7 @@ export class IframeProvider extends BasePopupProvider {
         // injected wallets don't need permissions here (handled by the wallet)
         if (this.isInjectedUser) return false
 
-        return checkIfRequestRequiresConfirmation(getIframeURL(), args)
+        return checkIfRequestRequiresConfirmation(getWalletURL(), args)
     }
 
     private get isInjectedUser() {
@@ -53,7 +53,7 @@ export class IframeProvider extends BasePopupProvider {
     }
 
     protected override handlePermissionless(key: UUID, args: EIP1193RequestParameters): undefined {
-        const req = { key, windowId: iframeID(), error: null, payload: args }
+        const req = { key, windowId: walletID(), error: null, payload: args }
         if (this.isInjectedUser) {
             void handleInjectedRequest(req)
         } else {

--- a/packages/core/lib/happyProvider/happyProvider.test.ts
+++ b/packages/core/lib/happyProvider/happyProvider.test.ts
@@ -9,9 +9,9 @@ import {
     type EventBusOptions,
     Msgs,
     type MsgsFromApp,
-    type MsgsFromIframe,
+    type MsgsFromWallet,
     type ProviderMsgsFromApp,
-    type ProviderMsgsFromIframe,
+    type ProviderMsgsFromWallet,
     ProviderRpcError,
     serializeRpcError,
 } from "@happy.tech/wallet-common"
@@ -47,19 +47,19 @@ const emptyRpcBlock = {
 } satisfies RpcBlock
 
 function newIframeProviderBus(options: EventBusOptions) {
-    return new EventBus<ProviderMsgsFromApp, ProviderMsgsFromIframe>(options)
+    return new EventBus<ProviderMsgsFromApp, ProviderMsgsFromWallet>(options)
 }
 
 function newIframeMessageBus(options: EventBusOptions) {
-    return new EventBus<MsgsFromApp, MsgsFromIframe>(options)
+    return new EventBus<MsgsFromApp, MsgsFromWallet>(options)
 }
 
 function newAppProviderBus(options: EventBusOptions) {
-    return new EventBus<ProviderMsgsFromIframe, ProviderMsgsFromApp>(options)
+    return new EventBus<ProviderMsgsFromWallet, ProviderMsgsFromApp>(options)
 }
 
 function newAppMessageBus(options: EventBusOptions) {
-    return new EventBus<MsgsFromIframe, MsgsFromApp>(options)
+    return new EventBus<MsgsFromWallet, MsgsFromApp>(options)
 }
 
 function createTestBusPair() {
@@ -127,7 +127,7 @@ describe("HappyProvider", () => {
 
     it("transmits payload using bus", async () => {
         // provider setup
-        void iframeMessageBus.emit(Msgs.IframeInit, true)
+        void iframeMessageBus.emit(Msgs.WalletInit, true)
         test_autoApprovePermissionCheck()
         void iframeMessageBus.emit(Msgs.AuthStateChanged, AuthState.Disconnected)
 
@@ -160,7 +160,7 @@ describe("HappyProvider", () => {
 
     it("resolves on success", async () => {
         // provider setup
-        void iframeMessageBus.emit(Msgs.IframeInit, true)
+        void iframeMessageBus.emit(Msgs.WalletInit, true)
         test_autoApprovePermissionCheck()
         void iframeMessageBus.emit(Msgs.AuthStateChanged, AuthState.Disconnected)
 
@@ -184,7 +184,7 @@ describe("HappyProvider", () => {
 
     it("rejects on error", async () => {
         // provider setup
-        void iframeMessageBus.emit(Msgs.IframeInit, true)
+        void iframeMessageBus.emit(Msgs.WalletInit, true)
         test_autoApprovePermissionCheck()
         void iframeMessageBus.emit(Msgs.AuthStateChanged, AuthState.Disconnected)
 

--- a/packages/core/lib/happyProvider/happyProviderImplem.ts
+++ b/packages/core/lib/happyProvider/happyProviderImplem.ts
@@ -11,10 +11,10 @@ import {
     LoginRequiredError,
     Msgs,
     type MsgsFromApp,
-    type MsgsFromIframe,
+    type MsgsFromWallet,
     type OverlayErrorCode,
     type ProviderMsgsFromApp,
-    type ProviderMsgsFromIframe,
+    type ProviderMsgsFromWallet,
     SafeEventEmitter,
     WalletDisplayAction,
     WalletType,
@@ -42,8 +42,8 @@ const mipdStore = createStore()
 export type HappyProviderConfig = Pick<typeof config, "iframePath"> & {
     logger?: Logger
     windowId: UUID
-    providerBus: EventBus<ProviderMsgsFromIframe, ProviderMsgsFromApp>
-    msgBus: EventBus<MsgsFromIframe, MsgsFromApp>
+    providerBus: EventBus<ProviderMsgsFromWallet, ProviderMsgsFromApp>
+    msgBus: EventBus<MsgsFromWallet, MsgsFromApp>
 }
 
 /**
@@ -67,11 +67,11 @@ export class HappyProviderImplem extends SafeEventEmitter implements HappyProvid
                     : new HappyProviderImplem({
                           iframePath: config.iframePath,
                           windowId: windowId as UUID,
-                          providerBus: new EventBus<ProviderMsgsFromIframe, ProviderMsgsFromApp>({
+                          providerBus: new EventBus<ProviderMsgsFromWallet, ProviderMsgsFromApp>({
                               mode: EventBusMode.AppPort,
                               scope: "happy-chain-eip1193-provider",
                           }),
-                          msgBus: new EventBus<MsgsFromIframe, MsgsFromApp>({
+                          msgBus: new EventBus<MsgsFromWallet, MsgsFromApp>({
                               mode: EventBusMode.AppPort,
                               scope: "happy-chain-dapp-bus",
                           }),
@@ -90,7 +90,7 @@ export class HappyProviderImplem extends SafeEventEmitter implements HappyProvid
     private authState: AuthState = AuthState.Initializing
     private lastConnectedType: WalletType | undefined
 
-    private iframeMsgBus: EventBus<MsgsFromIframe, MsgsFromApp>
+    private iframeMsgBus: EventBus<MsgsFromWallet, MsgsFromApp>
 
     /**
      * Initializes the Happy Account wallet state and communication with the iframe.
@@ -152,7 +152,7 @@ export class HappyProviderImplem extends SafeEventEmitter implements HappyProvid
      * injected wallet events are proxied through the iframe (which needs to learn of them),
      * then sent back.
      */
-    private handleProviderNativeEvent(data: ProviderMsgsFromIframe[Msgs.ProviderEvent]) {
+    private handleProviderNativeEvent(data: ProviderMsgsFromWallet[Msgs.ProviderEvent]) {
         this.emit(data.payload.event, data.payload.args)
     }
 

--- a/packages/core/lib/happyProvider/listeners.ts
+++ b/packages/core/lib/happyProvider/listeners.ts
@@ -4,7 +4,7 @@ import {
     type HappyUser,
     Msgs,
     type MsgsFromApp,
-    type MsgsFromIframe,
+    type MsgsFromWallet,
     type OverlayErrorCode,
 } from "@happy.tech/wallet-common"
 
@@ -49,7 +49,7 @@ function createListener<T>(callbacks: Set<T>, callback: T): ListenerUnsubscribeF
     }
 }
 
-export function registerListeners(messageBus: EventBus<MsgsFromIframe, MsgsFromApp>) {
+export function registerListeners(messageBus: EventBus<MsgsFromWallet, MsgsFromApp>) {
     const onUserUpdateCallbacks = new Set<UserUpdateCallback>()
     const onWalletVisibilityCallbacks = new Set<WalletVisibilityCallback>()
     const onIframeInitCallbacks = new Set<IframeInitCallback>()
@@ -59,7 +59,7 @@ export function registerListeners(messageBus: EventBus<MsgsFromIframe, MsgsFromA
     messageBus.on(Msgs.UserChanged, (user) => executeCallbacks(onUserUpdateCallbacks, user))
     messageBus.on(Msgs.AuthStateChanged, (state) => executeCallbacks(onAuthStateUpdateCallbacks, state))
     messageBus.on(Msgs.WalletVisibility, (isOpen) => executeCallbacks(onWalletVisibilityCallbacks, isOpen))
-    messageBus.on(Msgs.IframeInit, (isInit) => executeCallbacks(onIframeInitCallbacks, isInit))
+    messageBus.on(Msgs.WalletInit, (isInit) => executeCallbacks(onIframeInitCallbacks, isInit))
     messageBus.on(Msgs.DisplayOverlayError, (errorCode) => executeCallbacks(onDisplayOverlayErrorCallbacks, errorCode))
 
     /**

--- a/packages/core/lib/happyProvider/socialWalletHandler.ts
+++ b/packages/core/lib/happyProvider/socialWalletHandler.ts
@@ -1,5 +1,5 @@
 import { type UUID, createUUID, promiseWithResolvers } from "@happy.tech/common"
-import type { EIP1193RequestParameters, HappyUser, ProviderMsgsFromIframe } from "@happy.tech/wallet-common"
+import type { EIP1193RequestParameters, HappyUser, ProviderMsgsFromWallet } from "@happy.tech/wallet-common"
 import { AuthState, BasePopupProvider, LoginRequiredError, Msgs, OverlayErrorCode } from "@happy.tech/wallet-common"
 import { config } from "../config"
 import { type HappyProviderConfig, HappyProviderImplem } from "./happyProviderImplem"
@@ -42,7 +42,7 @@ export class SocialWalletHandler extends BasePopupProvider implements EIP1193Con
         config.providerBus.on(Msgs.PermissionCheckResponse, this.handlePermissionCheck.bind(this))
     }
 
-    private async handlePermissionCheck(data: ProviderMsgsFromIframe[Msgs.PermissionCheckResponse]) {
+    private async handlePermissionCheck(data: ProviderMsgsFromWallet[Msgs.PermissionCheckResponse]) {
         const inFlight = this.inFlightChecks.get(data.key)
         if (!inFlight) return
         if (typeof data.payload === "boolean") {

--- a/support/wallet-common/lib/classes/BasePopupProvider.ts
+++ b/support/wallet-common/lib/classes/BasePopupProvider.ts
@@ -2,7 +2,7 @@ import { type RejectType, type ResolveType, type UUID, createUUID, promiseWithRe
 import SafeEventEmitter from "@metamask/safe-event-emitter"
 import { LoginRequiredError, parseRpcError, standardizeRpcError } from "../errors"
 import type { EIP1193RequestParameters, EIP1193RequestResult } from "../interfaces/eip1193"
-import type { Msgs, ProviderMsgsFromIframe } from "../interfaces/events"
+import type { Msgs, ProviderMsgsFromWallet } from "../interfaces/events"
 
 type Timer = ReturnType<typeof setInterval>
 
@@ -95,7 +95,7 @@ export abstract class BasePopupProvider extends SafeEventEmitter {
      * The subclasses must make sure that this method gets called whenever the popup answers a
      * request.
      */
-    public handleRequestResolution(data: ProviderMsgsFromIframe[Msgs.RequestResponse]): void {
+    public handleRequestResolution(data: ProviderMsgsFromWallet[Msgs.RequestResponse]): void {
         const req = this.inFlightRequests.get(data.key)
         if (!req) return
 

--- a/support/wallet-common/lib/index.ts
+++ b/support/wallet-common/lib/index.ts
@@ -42,9 +42,9 @@ export type { EIP6963ProviderInfo, EIP6963ProviderDetail, EIP6963AnnounceProvide
 
 export type {
     MsgsFromApp,
-    MsgsFromIframe,
+    MsgsFromWallet,
     PopupMsgs,
-    ProviderMsgsFromIframe,
+    ProviderMsgsFromWallet,
     ProviderMsgsFromApp,
     ApprovedRequestPayload,
     RequestExtraData,

--- a/support/wallet-common/lib/interfaces/connectionProvider.ts
+++ b/support/wallet-common/lib/interfaces/connectionProvider.ts
@@ -1,4 +1,4 @@
-import type { Msgs, MsgsFromApp, MsgsFromIframe } from "./events"
+import type { Msgs, MsgsFromApp, MsgsFromWallet } from "./events"
 
 /**
  * Interface for a connectable provider (for injected or social wallets).
@@ -10,6 +10,6 @@ export interface ConnectionProvider {
     name: string
     icon: string
     type: string
-    connect: (request: MsgsFromApp[Msgs.ConnectRequest]) => Promise<MsgsFromIframe[Msgs.ConnectResponse]>
+    connect: (request: MsgsFromApp[Msgs.ConnectRequest]) => Promise<MsgsFromWallet[Msgs.ConnectResponse]>
     disconnect: () => Promise<void>
 }

--- a/support/wallet-common/lib/interfaces/events.ts
+++ b/support/wallet-common/lib/interfaces/events.ts
@@ -44,8 +44,8 @@ export enum Msgs {
 
     // --- EventsFromIframe ------------------------------------------------------------------------
 
-    /** Informs the SDK that the iframe has loaded and initialized. */
-    IframeInit = "iframe-init",
+    /** Informs the SDK that the wallet has loaded and initialized. */
+    WalletInit = "wallet-init",
 
     /** When sent from the iframe, this is received by the app and the overlay is displayed. */
     DisplayOverlayError = "display-overlay-error",
@@ -147,7 +147,7 @@ export type MsgsFromApp = {
               rdns: string
               address: `0x${string}`
               request: MsgsFromApp[Msgs.ConnectRequest]
-              response: MsgsFromIframe[Msgs.ConnectResponse]["response"]
+              response: MsgsFromWallet[Msgs.ConnectResponse]["response"]
           }
         | {
               // everything undefined means a disconnect
@@ -170,10 +170,10 @@ interface AuthResponse<
     response: EIP1193RequestResult<T> | null
 }
 /**
- * Events sent from the iframe to the app on the general message bus.
+ * Events sent from the wallet to the app on the general message bus.
  */
-export type MsgsFromIframe = {
-    [Msgs.IframeInit]: boolean
+export type MsgsFromWallet = {
+    [Msgs.WalletInit]: boolean
     [Msgs.DisplayOverlayError]: OverlayErrorCode
     [Msgs.ConnectResponse]: AuthResponse
     [Msgs.WalletVisibility]: { isOpen: boolean }
@@ -203,7 +203,7 @@ export type ProviderMsgsFromApp = {
  * Schema for messages that can be sent from the iframe to the app.
  */
 export type ProviderEvent = ProviderEventError<SerializedRpcError> | ProviderEventPayload<EIP1193RequestResult>
-export type ProviderMsgsFromIframe = {
+export type ProviderMsgsFromWallet = {
     [Msgs.RequestResponse]: ProviderEvent
     [Msgs.PermissionCheckResponse]: ProviderEventPayload<boolean> | ProviderEventError
     [Msgs.ExecuteInjectedRequest]: ProviderEventPayload<EIP1193RequestParameters>


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR renames various references from "iframe" to "wallet" throughout the codebase to better reflect the component's purpose. The changes include:

- Renamed `iframeID()` to `walletID()`
- Renamed `getIframeURL()` to `getWalletURL()`
- Renamed `isIframe()` to `isWallet()`
- Renamed `isStandaloneIframe()` to `isStandaloneWallet()`
- Added `isEmbeddedWallet()` function for clarity
- Updated message types from `MsgsFromIframe` to `MsgsFromWallet`
- Updated event name from `IframeInit` to `WalletInit`
- Updated related variable names and comments to maintain consistency

These changes improve code readability by using terminology that better describes the components' roles and relationships, making it clearer that we're dealing with a wallet that can be either embedded or standalone.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>