### PR TITLE
Replace NODE_ENV with DEV and improve wallet initialization warning message

### DIFF
--- a/apps/iframe/src/requests/handlers/injected.ts
+++ b/apps/iframe/src/requests/handlers/injected.ts
@@ -91,8 +91,7 @@ export async function dispatchInjectedRequest(request: ProviderMsgsFromApp[Msgs.
             //
             // We'll need to handle this flow in prod whenever we're
             // thinking to do a contract update in a released environment.
-            if (import.meta.env.NODE_ENV === "development")
-                isAuthorized &&= await isSessionKeyValidatorInstalled(user.address)
+            if (import.meta.env.DEV) isAuthorized &&= await isSessionKeyValidatorInstalled(user.address)
 
             if (isAuthorized) {
                 const sessionKey = getSessionKey(user.address, target)

--- a/apps/iframe/src/utils/appURL.ts
+++ b/apps/iframe/src/utils/appURL.ts
@@ -17,8 +17,8 @@ export const _parentID = new URLSearchParams(window.location.search).get("window
 /** ID generated for this wallet (tied to a specific app). */
 const _walletID = createUUID()
 
-if (!isWallet(getAppURL()) && !_parentID && process.env.NODE_ENV !== "test") {
-    console.warn("Wallet initialized without windowId")
+if (!isWallet(getAppURL()) && !_parentID) {
+    console.warn("Embedded Wallet initialized without windowId")
 }
 
 /**


### PR DESCRIPTION
### Description

This PR updates environment variable checks in the iframe app:

1. Simplifies the session key validator check by using `import.meta.env.DEV` instead of `import.meta.env.NODE_ENV === "development"`

2. Improves the warning message when the wallet is initialized without a windowId by:
   - Changing the message from "Wallet initialized without windowId" to "Embedded Wallet initialized without windowId"
   - Removing the test environment check (`process.env.NODE_ENV !== "test"`) to ensure the warning is shown in all environments

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>