### PR TITLE
use generateTestUser helper in tests

### DIFF
--- a/apps/iframe/src/requests/tests/eth_requestAccounts.cross_origin.spec.ts
+++ b/apps/iframe/src/requests/tests/eth_requestAccounts.cross_origin.spec.ts
@@ -1,4 +1,4 @@
-import { addressFactory, makePayload } from "@happy.tech/testing"
+import { generateTestUser, makePayload } from "@happy.tech/testing"
 import { AuthState, EIP1193UnauthorizedError, EIP1193UserRejectedRequestError } from "@happy.tech/wallet-common"
 import type { HappyUser } from "@happy.tech/wallet-common"
 import { beforeEach, describe, expect, test, vi } from "vitest"
@@ -6,7 +6,6 @@ import { dispatchedPermissionlessRequest } from "#src/requests/handlers/permissi
 import { setAuthState } from "#src/state/authState"
 import { clearPermissions, getAllPermissions, grantPermissions } from "#src/state/permissions.ts"
 import { setUser } from "#src/state/user"
-import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 
 const { appURL, parentID, appURLMock } = await vi //
     .hoisted(async () => await import("#src/testing/cross_origin.mocks"))
@@ -34,7 +33,7 @@ describe("#publicClient #eth_requestAccounts #cross_origin ", () => {
 
         beforeEach(async () => {
             clearPermissions()
-            user = await createHappyUserFromWallet("io.testing", addressFactory())
+            user = generateTestUser()
             setUser(user)
             setAuthState(AuthState.Connected)
         })
@@ -57,7 +56,7 @@ describe("#publicClient #eth_requestAccounts #cross_origin ", () => {
         })
 
         test("does not add permissions", async () => {
-            const user = await createHappyUserFromWallet("io.testing", addressFactory())
+            const user = generateTestUser()
             setUser(user)
             expect(getAllPermissions(appURL).length).toBe(0)
             const request = makePayload(parentID, { method: "eth_requestAccounts" })

--- a/apps/iframe/src/requests/tests/eth_requestAccounts.same_origin.spec.ts
+++ b/apps/iframe/src/requests/tests/eth_requestAccounts.same_origin.spec.ts
@@ -1,4 +1,4 @@
-import { addressFactory, makePayload } from "@happy.tech/testing"
+import { generateTestUser, makePayload } from "@happy.tech/testing"
 import { AuthState, EIP1193UnauthorizedError } from "@happy.tech/wallet-common"
 import type { HappyUser } from "@happy.tech/wallet-common"
 import { beforeEach, describe, expect, test } from "vitest"
@@ -6,7 +6,6 @@ import { vi } from "vitest"
 import { setAuthState } from "#src/state/authState"
 import { clearPermissions, getAllPermissions } from "#src/state/permissions.ts"
 import { setUser } from "#src/state/user"
-import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 import { dispatchedPermissionlessRequest } from "../handlers/permissionless"
 
 const { appURL, walletID, appURLMock } = await vi //
@@ -35,7 +34,7 @@ describe("#publicClient #eth_requestAccounts #same_origin", () => {
 
         beforeEach(async () => {
             clearPermissions()
-            user = await createHappyUserFromWallet("io.testing", addressFactory())
+            user = generateTestUser()
             setUser(user)
             setAuthState(AuthState.Connected)
         })

--- a/apps/iframe/src/requests/tests/wallet_requestPermissions.no_conf.cross_origin.spec.ts
+++ b/apps/iframe/src/requests/tests/wallet_requestPermissions.no_conf.cross_origin.spec.ts
@@ -1,4 +1,4 @@
-import { addressFactory, makePayload } from "@happy.tech/testing"
+import { generateTestUser, makePayload } from "@happy.tech/testing"
 import { AuthState, EIP1193UnauthorizedError } from "@happy.tech/wallet-common"
 import type { HappyUser } from "@happy.tech/wallet-common"
 import { beforeEach, describe, expect, test, vi } from "vitest"
@@ -6,7 +6,6 @@ import { dispatchedPermissionlessRequest } from "#src/requests/handlers/permissi
 import { setAuthState } from "#src/state/authState"
 import { clearPermissions, getAllPermissions } from "#src/state/permissions.ts"
 import { setUser } from "#src/state/user"
-import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 
 const { appURL, parentID, appURLMock } = await vi //
     .hoisted(async () => await import("#src/testing/cross_origin.mocks"))
@@ -37,7 +36,7 @@ describe("#publicClient #wallet_requestPermissions #cross_origin", () => {
 
         beforeEach(async () => {
             clearPermissions()
-            user = await createHappyUserFromWallet("io.testing", addressFactory())
+            user = generateTestUser()
             setUser(user)
             setAuthState(AuthState.Connected)
         })

--- a/apps/iframe/src/requests/tests/wallet_requestPermissions.no_conf.same_origin.spec.ts
+++ b/apps/iframe/src/requests/tests/wallet_requestPermissions.no_conf.same_origin.spec.ts
@@ -1,4 +1,4 @@
-import { addressFactory, makePayload } from "@happy.tech/testing"
+import { generateTestUser, makePayload } from "@happy.tech/testing"
 import { AuthState, EIP1193UnauthorizedError } from "@happy.tech/wallet-common"
 import type { HappyUser } from "@happy.tech/wallet-common"
 import { beforeEach, describe, expect, test } from "vitest"
@@ -7,7 +7,6 @@ import { dispatchedPermissionlessRequest } from "#src/requests/handlers/permissi
 import { setAuthState } from "#src/state/authState"
 import { clearPermissions, getAllPermissions } from "#src/state/permissions.ts"
 import { setUser } from "#src/state/user"
-import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 
 const { appURL, walletID, appURLMock } = await vi //
     .hoisted(async () => await import("#src/testing/same_origin.mocks"))
@@ -37,7 +36,7 @@ describe("#publicClient #wallet_requestPermissions #same_origin", () => {
         let user: HappyUser
         beforeEach(async () => {
             clearPermissions()
-            user = await createHappyUserFromWallet("io.testing", addressFactory())
+            user = generateTestUser()
             setUser(user)
             setAuthState(AuthState.Connected)
         })

--- a/apps/iframe/src/requests/tests/wallet_requestPermissions.user_conf.cross_origin.spec.ts
+++ b/apps/iframe/src/requests/tests/wallet_requestPermissions.user_conf.cross_origin.spec.ts
@@ -1,4 +1,4 @@
-import { addressFactory, makePayload } from "@happy.tech/testing"
+import { generateTestUser, makePayload } from "@happy.tech/testing"
 import { AuthState } from "@happy.tech/wallet-common"
 import type { HappyUser } from "@happy.tech/wallet-common"
 import { beforeEach, describe, expect, test, vi } from "vitest"
@@ -6,7 +6,6 @@ import { dispatchApprovedRequest } from "#src/requests/handlers/approved"
 import { setAuthState } from "#src/state/authState"
 import { clearPermissions, getAllPermissions } from "#src/state/permissions.ts"
 import { setUser } from "#src/state/user"
-import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 
 const { appURL, walletURL, parentID, appURLMock } = await vi //
     .hoisted(async () => await import("#src/testing/cross_origin.mocks"))
@@ -18,7 +17,7 @@ describe("#walletClient #wallet_requestPermissions #cross_origin", () => {
 
     beforeEach(async () => {
         clearPermissions()
-        user = await createHappyUserFromWallet("io.testing", addressFactory())
+        user = generateTestUser()
         setUser(user)
         setAuthState(AuthState.Connected)
     })

--- a/apps/iframe/src/requests/tests/wallet_requestPermissions.user_conf.same_origin.spec.ts
+++ b/apps/iframe/src/requests/tests/wallet_requestPermissions.user_conf.same_origin.spec.ts
@@ -1,4 +1,4 @@
-import { addressFactory, makePayload } from "@happy.tech/testing"
+import { generateTestUser, makePayload } from "@happy.tech/testing"
 import { AuthState } from "@happy.tech/wallet-common"
 import type { HappyUser } from "@happy.tech/wallet-common"
 import { beforeEach, describe, expect, test } from "vitest"
@@ -7,7 +7,6 @@ import { dispatchApprovedRequest } from "#src/requests/handlers/approved"
 import { setAuthState } from "#src/state/authState"
 import { clearPermissions, getAllPermissions } from "#src/state/permissions.ts"
 import { setUser } from "#src/state/user"
-import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 
 const { appURL, walletID, appURLMock } = await vi //
     .hoisted(async () => await import("#src/testing/same_origin.mocks"))
@@ -19,7 +18,7 @@ describe("#walletClient #wallet_requestPermissions #same_origin", () => {
 
     beforeEach(async () => {
         clearPermissions()
-        user = await createHappyUserFromWallet("io.testing", addressFactory())
+        user = generateTestUser()
         setUser(user)
         setAuthState(AuthState.Connected)
     })

--- a/apps/iframe/src/requests/tests/wallet_watchAsset.spec.ts
+++ b/apps/iframe/src/requests/tests/wallet_watchAsset.spec.ts
@@ -1,11 +1,10 @@
-import { addressFactory, makePayload } from "@happy.tech/testing"
+import { generateTestUser, makePayload } from "@happy.tech/testing"
 import { AuthState } from "@happy.tech/wallet-common"
 import type { HappyUser } from "@happy.tech/wallet-common"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 import { setAuthState } from "#src/state/authState"
 import { setUser } from "#src/state/user"
 import { getWatchedAssets } from "#src/state/watchedAssets.ts"
-import { createHappyUserFromWallet } from "#src/utils/createHappyUserFromWallet"
 import { dispatchApprovedRequest } from "../handlers/approved"
 
 const { walletID, appURLMock } = await vi //
@@ -17,7 +16,7 @@ describe("walletClient wallet_watchAsset", () => {
     let user: HappyUser
 
     beforeEach(async () => {
-        user = await createHappyUserFromWallet("io.testing", addressFactory())
+        user = generateTestUser()
         setUser(user)
         setAuthState(AuthState.Connected)
     })


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR adds the `make test` command to the GitHub Actions workflow and replaces the deprecated `addressFactory()` and `createHappyUserFromWallet()` functions with the new `generateTestUser()` utility across all test files.

The changes improve our testing infrastructure by:
1. Running tests as part of the CI pipeline
2. Standardizing how test users are generated in our test suite

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>