### PR TITLE
feat: add visual indicator for user's gas remaining gas budget fetched from the paymaster

### DIFF
--- a/.changeset/nine-apes-attend.md
+++ b/.changeset/nine-apes-attend.md
@@ -1,0 +1,5 @@
+---
+"@happy.tech/iframe": minor
+---
+
+Adds a visual indicator in the wallet for user's paymaster gas budget.

--- a/apps/iframe/src/components/interface/GlobalHeader.tsx
+++ b/apps/iframe/src/components/interface/GlobalHeader.tsx
@@ -5,6 +5,7 @@ import { Link, useLocation } from "@tanstack/react-router"
 import { useAtom } from "jotai"
 import { appMessageBus } from "#src/services/eventBus"
 import { secondaryMenuVisibilityAtom } from "#src/state/interfaceState"
+import { UserGasBudgetIndicator } from "./home/UserGasBudgetIndicator"
 
 function signalClosed() {
     void appMessageBus.emit(Msgs.WalletVisibility, { isOpen: false })
@@ -27,6 +28,7 @@ const GlobalHeader = () => {
             </span>
 
             <div className="flex flex-row gap-1 items-center absolute end-2">
+                <UserGasBudgetIndicator />
                 <button
                     title={optionsLabel}
                     type="button"

--- a/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
+++ b/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
@@ -1,18 +1,18 @@
 import {
-    BatteryFull,
-    BatteryHigh,
-    BatteryLow,
-    BatteryMedium,
-    BatteryWarning,
+    BatteryFullIcon,
+    BatteryHighIcon,
+    BatteryLowIcon,
+    BatteryMediumIcon,
+    BatteryWarningIcon,
     type Icon,
-    Spinner,
+    SpinnerIcon,
 } from "@phosphor-icons/react"
 import { cx } from "class-variance-authority"
 import type { ClassValue } from "class-variance-authority/types"
-import { type BatteryHealthIndicator, useReadUserGasBudget } from "#src/hooks/useReadUserGasBudget.ts"
+import { useReadUserGasBudget } from "#src/hooks/useReadUserGasBudget.ts"
 import { getUser } from "#src/state/user.ts"
 
-const colorMap: Record<BatteryHealthIndicator, ClassValue> = {
+const colorMap: Record<number, ClassValue> = {
     0: "text-error animate-pulse",
     1: "text-warning/60",
     2: "text-warning",
@@ -23,12 +23,12 @@ const colorMap: Record<BatteryHealthIndicator, ClassValue> = {
 /**
  * Maps each battery health level to the corresponding Phosphor Icon component.
  */
-const batteryIconStates: Record<BatteryHealthIndicator, Icon> = {
-    0: BatteryWarning,
-    1: BatteryLow,
-    2: BatteryMedium,
-    3: BatteryHigh,
-    4: BatteryFull,
+const batteryIconStates: Record<number, Icon> = {
+    0: BatteryWarningIcon,
+    1: BatteryLowIcon,
+    2: BatteryMediumIcon,
+    3: BatteryHighIcon,
+    4: BatteryFullIcon,
 }
 
 export const UserGasBudgetIndicator = () => {
@@ -39,7 +39,7 @@ export const UserGasBudgetIndicator = () => {
     } = useReadUserGasBudget(user?.address)
 
     if (isLoading || batteryHealth === undefined)
-        return <Spinner weight="bold" className="text-lg mr-1 dark:opacity-60" />
+        return <SpinnerIcon weight="bold" className="text-lg mr-1 dark:opacity-60" />
 
     const BatteryIcon = batteryIconStates[batteryHealth]
     const colorClass = colorMap[batteryHealth]

--- a/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
+++ b/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
@@ -1,0 +1,50 @@
+import {
+    BatteryEmpty,
+    BatteryFull,
+    BatteryHigh,
+    BatteryLow,
+    BatteryMedium,
+    type Icon,
+    Spinner,
+} from "@phosphor-icons/react"
+import { cx } from "class-variance-authority"
+import type { ClassValue } from "class-variance-authority/types"
+import { type BatteryHealthIndicator, useReadUserGasBudget } from "#src/hooks/useReadUserGasBudget.ts"
+import { getUser } from "#src/state/user.ts"
+
+const colorMap: Record<BatteryHealthIndicator, ClassValue> = {
+    0: "text-error animate-pulse",
+    1: "text-warning/60",
+    2: "text-warning",
+    3: "text-success/80",
+    4: "text-success",
+}
+
+const batteryIconStates: Record<BatteryHealthIndicator, Icon> = {
+    0: BatteryEmpty,
+    1: BatteryLow,
+    2: BatteryMedium,
+    3: BatteryHigh,
+    4: BatteryFull,
+}
+
+export const UserGasBudgetIndicator = () => {
+    const user = getUser()
+    const {
+        data: { batteryHealth, batteryPct } = {},
+        isLoading,
+    } = useReadUserGasBudget(user?.address)
+
+    console.log({ batteryHealth, batteryPct })
+
+    if (isLoading || batteryHealth === undefined) return <Spinner weight="bold" className="text-lg mr-1 dark:opacity-60" />
+
+    const BatteryIcon = batteryIconStates[batteryHealth]
+    const colorClass = colorMap[batteryHealth]
+
+    return (
+        <button title={`${batteryPct}%`} type="button" aria-label={"gas budget"} className="dark:opacity-60">
+            <BatteryIcon weight="bold" className={cx(colorClass, "text-lg", "mr-1")} />
+        </button>
+    )
+}

--- a/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
+++ b/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
@@ -1,9 +1,9 @@
 import {
-    BatteryEmpty,
     BatteryFull,
     BatteryHigh,
     BatteryLow,
     BatteryMedium,
+    BatteryWarning,
     type Icon,
     Spinner,
 } from "@phosphor-icons/react"
@@ -20,8 +20,11 @@ const colorMap: Record<BatteryHealthIndicator, ClassValue> = {
     4: "text-success",
 }
 
+/**
+ * Maps each battery health level to the corresponding Phosphor Icon component.
+ */
 const batteryIconStates: Record<BatteryHealthIndicator, Icon> = {
-    0: BatteryEmpty,
+    0: BatteryWarning,
     1: BatteryLow,
     2: BatteryMedium,
     3: BatteryHigh,

--- a/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
+++ b/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
@@ -39,7 +39,12 @@ export const UserGasBudgetIndicator = () => {
     } = useReadUserGasBudget(user?.address)
 
     if (isLoading || batteryHealth === undefined)
-        return <SpinnerIcon weight="bold" className="text-lg mr-1 dark:opacity-60 motion-safe:animate-[spin_2s_linear_infinite]" />
+        return (
+            <SpinnerIcon
+                weight="bold"
+                className="text-lg mr-1 dark:opacity-60 motion-safe:animate-[spin_2s_linear_infinite]"
+            />
+        )
 
     const BatteryIcon = batteryIconStates[batteryHealth]
     const colorClass = colorMap[batteryHealth]

--- a/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
+++ b/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
@@ -35,9 +35,8 @@ export const UserGasBudgetIndicator = () => {
         isLoading,
     } = useReadUserGasBudget(user?.address)
 
-    console.log({ batteryHealth, batteryPct })
-
-    if (isLoading || batteryHealth === undefined) return <Spinner weight="bold" className="text-lg mr-1 dark:opacity-60" />
+    if (isLoading || batteryHealth === undefined)
+        return <Spinner weight="bold" className="text-lg mr-1 dark:opacity-60" />
 
     const BatteryIcon = batteryIconStates[batteryHealth]
     const colorClass = colorMap[batteryHealth]

--- a/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
+++ b/apps/iframe/src/components/interface/home/UserGasBudgetIndicator.tsx
@@ -39,7 +39,7 @@ export const UserGasBudgetIndicator = () => {
     } = useReadUserGasBudget(user?.address)
 
     if (isLoading || batteryHealth === undefined)
-        return <SpinnerIcon weight="bold" className="text-lg mr-1 dark:opacity-60" />
+        return <SpinnerIcon weight="bold" className="text-lg mr-1 dark:opacity-60 motion-safe:animate-[spin_2s_linear_infinite]" />
 
     const BatteryIcon = batteryIconStates[batteryHealth]
     const colorClass = colorMap[batteryHealth]

--- a/apps/iframe/src/constants/contracts.ts
+++ b/apps/iframe/src/constants/contracts.ts
@@ -46,6 +46,7 @@ export const abis = getBoopAbis(chainId)
 export const entryPointAbi = abis.EntryPoint
 export const extensibleAccountAbi = abis.HappyAccountImpl
 export const sessionKeyValidatorAbi = abis.SessionKeyValidator
+export const happyPaymasterAbi = abis.HappyPaymaster
 
 //== Paymaster Selectors ===========================================================================
 

--- a/apps/iframe/src/hooks/useReadUserGasBudget.ts
+++ b/apps/iframe/src/hooks/useReadUserGasBudget.ts
@@ -8,28 +8,12 @@ import { happyPaymaster, happyPaymasterAbi } from "#src/constants/contracts"
 const MAX_GAS_BUDGET: UInt32 = 1_000_000_000
 
 /**
- * Battery health level index (0–4) representing gas budget tiers.
- */
-export type BatteryHealthIndicator = 0 | 1 | 2 | 3 | 4
-
-/**
- * Thresholds dividing the `MAX_GAS_BUDGET` into five discrete battery levels.
- */
-const BUDGET_THRESHOLDS = [
-    0, // Empty (Critical)
-    MAX_GAS_BUDGET / 4, // 1: Low (250_000_000)
-    (MAX_GAS_BUDGET * 2) / 4, // 2: Medium (500_000_000)
-    (MAX_GAS_BUDGET * 3) / 4, // 3: High (750_000_000)
-    MAX_GAS_BUDGET, // 4: Full (1_000_000_000)
-]
-
-/**
  * Structured gas budget info for UI display:
  * - `batteryHealth`: discrete level 0–4
  * - `batteryPct`: percentage of MAX_GAS_BUDGET (0–100).
  */
 export type UserGasBudgetInfo = {
-    batteryHealth: BatteryHealthIndicator
+    batteryHealth: number
     batteryPct: number
 }
 
@@ -68,17 +52,10 @@ export const useReadUserGasBudget = (userAddress?: Address): UseReadUserGasBudge
              * @param userGasBudget - raw uint32 gas budget from contract
              */
             select(userGasBudget) {
-                let batteryHealth: BatteryHealthIndicator = 0
-                for (let i = BUDGET_THRESHOLDS.length - 1; i >= 0; i--) {
-                    if (0 >= BUDGET_THRESHOLDS[i]) {
-                        batteryHealth = i as BatteryHealthIndicator
-                        break
-                    }
-                }
-
+                const pct = userGasBudget / MAX_GAS_BUDGET
                 return {
-                    batteryHealth,
-                    batteryPct: Number(((userGasBudget / MAX_GAS_BUDGET) * 100).toFixed(2)),
+                    batteryHealth: Math.round(pct * 4),
+                    batteryPct: Number((pct * 100).toFixed(2)),
                 }
             },
         },

--- a/apps/iframe/src/hooks/useReadUserGasBudget.ts
+++ b/apps/iframe/src/hooks/useReadUserGasBudget.ts
@@ -8,11 +8,11 @@ const MAX_GAS_BUDGET: UInt32 = 1_000_000_000
 export type BatteryHealthIndicator = 0 | 1 | 2 | 3 | 4
 
 const BUDGET_THRESHOLDS = [
-    0,
-    MAX_GAS_BUDGET / 4, // 250_000_000
-    (MAX_GAS_BUDGET * 2) / 4, // 500_000_000
-    (MAX_GAS_BUDGET * 3) / 4, // 750_000_000
-    MAX_GAS_BUDGET,
+    0, // Empty (Critical)
+    MAX_GAS_BUDGET / 4, // 1: Low (250_000_000)
+    (MAX_GAS_BUDGET * 2) / 4, // 2: Medium (500_000_000)
+    (MAX_GAS_BUDGET * 3) / 4, // 3: High (750_000_000)
+    MAX_GAS_BUDGET, // 4: Full (1_000_000_000)
 ]
 
 export type UserGasBudgetInfo = {

--- a/apps/iframe/src/hooks/useReadUserGasBudget.ts
+++ b/apps/iframe/src/hooks/useReadUserGasBudget.ts
@@ -36,7 +36,8 @@ export const useReadUserGasBudget = (userAddress?: Address): UseReadUserGasBudge
         functionName: "getBudget",
         args: [userAddress],
         query: {
-            enabled: Boolean(userAddress),
+            enabled: Boolean(!!userAddress),
+            refetchInterval: 2000,
             select(userGasBudget) {
                 let batteryHealth: BatteryHealthIndicator = 0
                 for (let i = BUDGET_THRESHOLDS.length - 1; i >= 0; i--) {

--- a/apps/iframe/src/hooks/useReadUserGasBudget.ts
+++ b/apps/iframe/src/hooks/useReadUserGasBudget.ts
@@ -1,0 +1,58 @@
+import type { Address, UInt32 } from "@happy.tech/common"
+import { type UseReadContractReturnType, useReadContract } from "wagmi"
+import { happyPaymaster, happyPaymasterAbi } from "#src/constants/contracts"
+
+// constant defined in the HappyPaymaster contract
+const MAX_GAS_BUDGET: UInt32 = 1_000_000_000
+
+export type BatteryHealthIndicator = 0 | 1 | 2 | 3 | 4
+
+const BUDGET_THRESHOLDS = [
+    0,
+    MAX_GAS_BUDGET / 4, // 250_000_000
+    (MAX_GAS_BUDGET * 2) / 4, // 500_000_000
+    (MAX_GAS_BUDGET * 3) / 4, // 750_000_000
+    MAX_GAS_BUDGET,
+]
+
+export type UserGasBudgetInfo = {
+    batteryHealth: BatteryHealthIndicator
+    batteryPct: number
+}
+
+export type UseReadUserGasBudgetReturnType = UseReadContractReturnType<
+    typeof happyPaymasterAbi,
+    "getBudget",
+    [Address],
+    UserGasBudgetInfo
+>
+
+export const useReadUserGasBudget = (userAddress?: Address): UseReadUserGasBudgetReturnType => {
+    if (!userAddress) throw new Error("No user found!")
+
+    const result = useReadContract({
+        address: happyPaymaster,
+        abi: happyPaymasterAbi,
+        functionName: "getBudget",
+        args: [userAddress],
+        query: {
+            enabled: Boolean(userAddress),
+            select(userGasBudget) {
+                let batteryHealth: BatteryHealthIndicator = 0
+                for (let i = BUDGET_THRESHOLDS.length - 1; i >= 0; i--) {
+                    if (userGasBudget >= BUDGET_THRESHOLDS[i]) {
+                        batteryHealth = i as BatteryHealthIndicator
+                        break
+                    }
+                }
+
+                return {
+                    batteryHealth,
+                    batteryPct: Number(((userGasBudget / MAX_GAS_BUDGET) * 100).toFixed(2)),
+                }
+            },
+        },
+    })
+
+    return result
+}

--- a/apps/iframe/src/hooks/useReadUserGasBudget.ts
+++ b/apps/iframe/src/hooks/useReadUserGasBudget.ts
@@ -2,11 +2,19 @@ import type { Address, UInt32 } from "@happy.tech/common"
 import { type UseReadContractReturnType, useReadContract } from "wagmi"
 import { happyPaymaster, happyPaymasterAbi } from "#src/constants/contracts"
 
-// constant defined in the HappyPaymaster contract
+/**
+ * Maximum cumulative gas budget per user as defined in the HappyPaymaster contract.
+ */
 const MAX_GAS_BUDGET: UInt32 = 1_000_000_000
 
+/**
+ * Battery health level index (0–4) representing gas budget tiers.
+ */
 export type BatteryHealthIndicator = 0 | 1 | 2 | 3 | 4
 
+/**
+ * Thresholds dividing the `MAX_GAS_BUDGET` into five discrete battery levels.
+ */
 const BUDGET_THRESHOLDS = [
     0, // Empty (Critical)
     MAX_GAS_BUDGET / 4, // 1: Low (250_000_000)
@@ -15,11 +23,19 @@ const BUDGET_THRESHOLDS = [
     MAX_GAS_BUDGET, // 4: Full (1_000_000_000)
 ]
 
+/**
+ * Structured gas budget info for UI display:
+ * - `batteryHealth`: discrete level 0–4
+ * - `batteryPct`: percentage of MAX_GAS_BUDGET (0–100).
+ */
 export type UserGasBudgetInfo = {
     batteryHealth: BatteryHealthIndicator
     batteryPct: number
 }
 
+/**
+ * Wagmi return type for the `getBudget` read call, mapped to `UserGasBudgetInfo`.
+ */
 export type UseReadUserGasBudgetReturnType = UseReadContractReturnType<
     typeof happyPaymasterAbi,
     "getBudget",
@@ -27,6 +43,15 @@ export type UseReadUserGasBudgetReturnType = UseReadContractReturnType<
     UserGasBudgetInfo
 >
 
+/**
+ * Hook to fetch and map a user's gas budget from the HappyPaymaster contract.
+ *
+ * @param userAddress - address of the user whose budget to read
+ * @returns Wagmi query object with:
+ *   - `data`: `{ batteryHealth, batteryPct }`
+ *   - `isLoading`, `isError`, `refetch`, etc.
+ * @throws Error if no userAddress is provided.
+ */
 export const useReadUserGasBudget = (userAddress?: Address): UseReadUserGasBudgetReturnType => {
     if (!userAddress) throw new Error("No user found!")
 
@@ -38,10 +63,14 @@ export const useReadUserGasBudget = (userAddress?: Address): UseReadUserGasBudge
         query: {
             enabled: Boolean(!!userAddress),
             refetchInterval: 2000,
+            /**
+             * Maps the raw onchain gas budget to UI-friendly battery info.
+             * @param userGasBudget - raw uint32 gas budget from contract
+             */
             select(userGasBudget) {
                 let batteryHealth: BatteryHealthIndicator = 0
                 for (let i = BUDGET_THRESHOLDS.length - 1; i >= 0; i--) {
-                    if (userGasBudget >= BUDGET_THRESHOLDS[i]) {
+                    if (0 >= BUDGET_THRESHOLDS[i]) {
                         batteryHealth = i as BatteryHealthIndicator
                         break
                     }


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-519/add-visual-indicator-for-paymaster-within-wallet

### Description

Added a gas budget indicator in the global header that displays the user's remaining gas budget as a battery icon. The indicator shows different battery states based on the user's remaining gas budget percentage:

- Empty/Critical: Red, pulsing battery icon (0%)
- Low: Amber/warning at low opacity (1-25%)
- Medium: Amber/warning (26-50%)
- High: Success color at lower opacity (51-75%)
- Full: Success color (76-100%)

The implementation includes:
- A new `UserGasBudgetIndicator` component that displays the appropriate battery icon
- A new hook `useReadUserGasBudget` that fetches the user's gas budget from the HappyPaymaster contract
- Integration with the global header to display the indicator next to the options button

The indicator shows a loading spinner while fetching data and displays a tooltip with the exact percentage when hovering over the battery icon.

## Testing

t1: run `make select-chain-local` (assuming all env files are populated wrt their corr. `.env.example`
t2: `make anvil`
t3: `make deploy-boop USE_FOUNDRY_ACCOUNT=false`, then `make deploy-mocks USE_FOUNDRY_ACCOUNT=false`
t4: `cd apps/submitter` && `make dev` (`migrate` if fresh run, then `dev`)

then run `make demo-react.dev` and the read should be successful 👌 

to test different battery states, I simply returned different values from within the hook as a `Number` instead of the read `userGasBudget` within the budget thresholds, to trigger different UI states. 

Ideally we'd want to replicate a few `cast` calls from the user's address, to make a significant dent to the user's gas budget, but that's not been slated for immediate effect.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>