### PR TITLE
feat: add slack notification for failing submitter crons

### DIFF
--- a/.github/workflows/submitter-cron.yml
+++ b/.github/workflows/submitter-cron.yml
@@ -21,15 +21,13 @@ jobs:
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: '1.2.4'
-      # - name: Build submitter & boop sdk
-      #   run: |
-      #       make submitter.build
-      # - name: Execute boop
-      #   run: |
-      #     cd support/testing
-      #     bun executeDummyBoop.ts
-      - name: Force a failure
-        run: exit 1
+      - name: Build submitter & boop sdk
+        run: |
+            make submitter.build
+      - name: Execute boop
+        run: |
+          cd support/testing
+          bun executeDummyBoop.ts
       - name: Send failure to Slack
         if: failure() # Only on failure
         uses: slackapi/slack-github-action@v2.1.0
@@ -39,5 +37,5 @@ jobs:
           payload: |
             {
               "channel": "C08JMNRJNR1",
-              "text": "❌ Workflow *${{ github.workflow }}* failed on *${{ github.ref_name }}*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+              "text": "❌ Workflow *${{ github.workflow }}* failed on *${{ github.ref_name }}*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Failing Workflow Logs>"
             }


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

< DESCRIPTION GOES HERE >

- Include all relevant context (but no need to repeat the issue's content).
- Draw attention to new, noteworthy & unintuitive elements.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>
