### PR TITLE
Fix code style and reorder imports

### DIFF
--- a/apps/faucet/src/services/faucet.ts
+++ b/apps/faucet/src/services/faucet.ts
@@ -1,5 +1,5 @@
-import { TransactionManager, TransactionStatus } from "@happy.tech/txm"
 import type { Address } from "@happy.tech/common"
+import { TransactionManager, TransactionStatus } from "@happy.tech/txm"
 import { type Result, err, ok } from "neverthrow"
 import { env } from "../env"
 import { FaucetRateLimitError } from "../errors"
@@ -33,7 +33,7 @@ export class FaucetService {
             const lastRequest = faucetUsageResult.value[0]
             const timeToWait =
                 lastRequest.occurredAt.getTime() + env.FAUCET_RATE_LIMIT_WINDOW_SECONDS * 1000 - Date.now()
-            
+
             if (timeToWait > 0) {
                 return err(new FaucetRateLimitError(timeToWait))
             }

--- a/support/common/lib/utils/time.ts
+++ b/support/common/lib/utils/time.ts
@@ -4,15 +4,15 @@ const unit = {
     m: 60e3,
     h: 3_600e3,
     d: 86_400e3,
-  } as const;
-  
+} as const
+
 export function formatMs(ms: number, long = false): string {
-    const abs = Math.abs(ms);
+    const abs = Math.abs(ms)
     for (const [abbr, size] of Object.entries(unit).reverse()) {
         if (abs >= size) {
-        const val = Math.round(ms / size);
-        return long ? `${val} ${abbr}${Math.abs(val) !== 1 ? 's' : ''}` : `${val}${abbr}`;
+            const val = Math.round(ms / size)
+            return long ? `${val} ${abbr}${Math.abs(val) !== 1 ? "s" : ""}` : `${val}${abbr}`
         }
     }
-    return `${ms}ms`;
+    return `${ms}ms`
 }


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR makes code style improvements across the codebase:

1. Reordered imports in the faucet service to follow a consistent pattern (types first, then implementations)
2. Removed trailing whitespace in the faucet service
3. Updated the time utility formatting to use consistent semicolons (removed) and double quotes instead of single quotes
4. Fixed code formatting and spacing in the time utility module

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>