### PR TITLE
Add updateBoopFromSimulation utility and fix typos

### DIFF
--- a/apps/iframe/src/components/requests/EthSendTransaction.tsx
+++ b/apps/iframe/src/components/requests/EthSendTransaction.tsx
@@ -65,7 +65,7 @@ export const EthSendTransaction = ({
         roundedCost += cost % MIN_DISPLAY_WEI > MIN_DISPLAY_WEI / 2n ? MIN_DISPLAY_WEI : 0n
         return {
             cost,
-            submitterFee: simulateOutput.submitterFee,
+            submitterFee,
             f: {
                 // formatted values
                 cost: cost < MIN_DISPLAY_WEI ? MIN_DISPLAY_STR : formatEther(roundedCost),

--- a/apps/iframe/src/requests/utils/boop.ts
+++ b/apps/iframe/src/requests/utils/boop.ts
@@ -105,7 +105,7 @@ export async function sendBoop(
 
     try {
         const boopClient = getBoopClient()
-        const boop = await boopFromTransaction(account, tx)
+        let boop = await boopFromTransaction(account, tx)
 
         let simulation = sim
         if (!isSponsored) {
@@ -114,12 +114,7 @@ export async function sendBoop(
             if (output.status !== Onchain.Success) throw translateBoopError(output)
             simulation = output
 
-            boop.gasLimit = output.gas
-            boop.validateGasLimit = output.validateGas
-            boop.validatePaymentGasLimit = output.validatePaymentGas
-            boop.executeGasLimit = output.executeGas
-            boop.maxFeePerGas = output.maxFeePerGas
-            boop.submitterFee = output.submitterFee
+            boop = boopClient.updateBoopFromSimulation(boop, output)
         }
 
         if (simulation?.feeTooLowDuringSimulation && boop.maxFeePerGas)

--- a/apps/submitter/lib/handlers/getState/getState.ts
+++ b/apps/submitter/lib/handlers/getState/getState.ts
@@ -14,7 +14,7 @@ export async function getState(input: GetStateInput): Promise<GetStateOutput> {
         if (!boop) return { status: GetState.UnknownBoop, description: "Unknown boop." }
         return {
             status: GetState.UnknownState,
-            description: "The boop is known, but there is no receipt or sinmulation data to serve.",
+            description: "The boop is known, but there is no receipt or simulation data to serve.",
         }
     } catch (error) {
         return outputForGenericError(error)

--- a/packages/boop-sdk/lib/client.spec.ts
+++ b/packages/boop-sdk/lib/client.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test"
 import { deployment } from "@happy.tech/contracts/boop/anvil"
 import { anvil } from "viem/chains"
 import { BoopClient } from "./client"
-import { GetNonce } from "./utils/getNonce"
+import { GetNonce } from "./types/GetNonce"
 
 const setupOptions = {
     baseUrl: "http://localhost:3001",

--- a/packages/boop-sdk/lib/index.ts
+++ b/packages/boop-sdk/lib/index.ts
@@ -117,9 +117,9 @@ export {
 
 export {
     GetNonce,
-    type GetNonceStatus,
+    type GetNonceError,
     type GetNonceInput,
     type GetNonceOutput,
+    type GetNonceStatus,
     type GetNonceSuccess,
-    type GetNonceError,
-} from "./utils/getNonce"
+} from "./types/GetNonce"

--- a/packages/boop-sdk/lib/types/GetNonce.ts
+++ b/packages/boop-sdk/lib/types/GetNonce.ts
@@ -1,0 +1,25 @@
+export type GetNonceInput = {
+    /** Happy Account Address */
+    address: `0x${string}`
+    /** Nonce Track */
+    nonceTrack: bigint
+}
+
+export const GetNonce = {
+    Success: "getNonceSuccess",
+    Error: "getNonceError",
+} as const
+
+export type GetNonceStatus = (typeof GetNonce)[keyof typeof GetNonce]
+
+export type GetNonceOutput = GetNonceSuccess | GetNonceError
+
+export type GetNonceSuccess = GetNonceInput & {
+    status: typeof GetNonce.Success
+    nonceValue: bigint
+}
+
+export type GetNonceError = GetNonceInput & {
+    status: typeof GetNonce.Error
+    description: string
+}

--- a/packages/boop-sdk/lib/utils/getNonce.ts
+++ b/packages/boop-sdk/lib/utils/getNonce.ts
@@ -1,30 +1,5 @@
 import { stringify } from "@happy.tech/common"
-
-export type GetNonceInput = {
-    /** Happy Account Address */
-    address: `0x${string}`
-    /** Nonce Track */
-    nonceTrack: bigint
-}
-
-export const GetNonce = {
-    Success: "getNonceSuccess",
-    Error: "getNonceError",
-} as const
-
-export type GetNonceStatus = (typeof GetNonce)[keyof typeof GetNonce]
-
-export type GetNonceOutput = GetNonceSuccess | GetNonceError
-
-export type GetNonceSuccess = GetNonceInput & {
-    status: typeof GetNonce.Success
-    nonceValue: bigint
-}
-
-export type GetNonceError = GetNonceInput & {
-    status: typeof GetNonce.Error
-    description: string
-}
+import { GetNonce, type GetNonceInput, type GetNonceOutput } from "../types/GetNonce"
 
 // "nonceValues(address,uint192)(uint64)"
 const nonceValuesSelector = "0xe631c8f2"

--- a/support/wallet-common/lib/interfaces/boop.ts
+++ b/support/wallet-common/lib/interfaces/boop.ts
@@ -1,7 +1,7 @@
 import type { Bytes, UInt32 } from "@happy.tech/common"
 
 /**
- * Copied from `apps/submitter/lib/types/EntryPointOutput.ts` to avoid depenency madness.
+ * Copied from `apps/submitter/lib/types/EntryPointOutput.ts` to avoid dependency madness.
  */
 enum CallStatus {
     SUCCEEDED = 0,
@@ -11,7 +11,7 @@ enum CallStatus {
 }
 
 /**
- * Copied from `apps/submitter/lib/types/EntryPointOutput.ts` to avoid depenency madness.
+ * Copied from `apps/submitter/lib/types/EntryPointOutput.ts` to avoid dependency madness.
  */
 type EntryPointOutput = {
     /**
@@ -69,7 +69,7 @@ type EntryPointOutput = {
 }
 
 /**
- * Copied from `apps/submitter/lib/handlers/simulate/types.ts` to avoid depenency madness.
+ * Copied from `apps/submitter/lib/handlers/simulate/types.ts` to avoid dependency madness.
  */
 export type SimulateSuccess = EntryPointOutput & {
     status: "onchainSuccess"


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR adds a utility function `updateBoopFromSimulation` to the BoopClient class that updates a Boop object with gas values from a successful simulation. The function is then used in the sendBoop function to simplify the code.

The PR also:
- Fixes a typo in the getState handler ("sinmulation" → "simulation")
- Moves GetNonce types to a dedicated file in the types directory
- Fixes a bug in EthSendTransaction where the submitterFee was incorrectly referenced from simulateOutput instead of using the local variable

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>