### PR TITLE
Add transaction replacement to prevent stuck transactions

### DIFF
--- a/apps/submitter/lib/services/ExecutorHeap.ts
+++ b/apps/submitter/lib/services/ExecutorHeap.ts
@@ -5,6 +5,74 @@ interface Executor {
     jobCount: number
 }
 
+export class BaseHeap<T> {
+    protected heap: T[] = []
+    private compare: (a: T, b: T) => boolean
+
+    constructor(compare: (a: T, b: T) => boolean) {
+        this.compare = compare
+    }
+
+    protected getParentIndex(index: number): number {
+        return Math.floor((index - 1) / 2)
+    }
+
+    protected getLeftChildIndex(index: number): number {
+        return 2 * index + 1
+    }
+
+    protected getRightChildIndex(index: number): number {
+        return 2 * index + 2
+    }
+
+    protected swap(index1: number, index2: number): void {
+        ;[this.heap[index1], this.heap[index2]] = [this.heap[index2], this.heap[index1]]
+    }
+
+    protected bubbleUp(index: number): void {
+        let currentIndex = index
+        while (currentIndex > 0) {
+            const parentIndex = this.getParentIndex(currentIndex)
+            if (this.compare(this.heap[currentIndex], this.heap[parentIndex])) {
+                this.swap(currentIndex, parentIndex)
+                currentIndex = parentIndex
+            } else {
+                break
+            }
+        }
+    }
+
+    protected bubbleDown(index: number): void {
+        let currentIndex = index
+        let nextIndex = currentIndex
+
+        while (true) {
+            const left = this.getLeftChildIndex(currentIndex)
+            const right = this.getRightChildIndex(currentIndex)
+
+            if (left < this.heap.length && this.compare(this.heap[left], this.heap[nextIndex])) {
+                nextIndex = left
+            }
+            if (right < this.heap.length && this.compare(this.heap[right], this.heap[nextIndex])) {
+                nextIndex = right
+            }
+
+            if (nextIndex === currentIndex) break
+
+            this.swap(currentIndex, nextIndex)
+            currentIndex = nextIndex
+        }
+    }
+
+    public peek(): T | undefined {
+        return this.heap[0]
+    }
+
+    public get values(): T[] {
+        return [...this.heap]
+    }
+}
+
 /**
  * MinHeap to track Executors by job count.
  * The executor with the least job count is at the top of the heap and can be accessed with .peek()


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR implements transaction replacement functionality to handle stuck transactions. When a transaction doesn't confirm within a timeout period, the system will automatically attempt to replace it with a higher gas price transaction.

Key changes:
- Added transaction replacement logic in `ReceiptService` that monitors transaction confirmation and replaces stuck transactions
- Implemented a timeout mechanism that triggers after ~2 blocks if a transaction hasn't been confirmed
- Added support for repricing transactions with 10% higher gas fees when replacing
- Created a fallback mechanism to send a no-op transaction if replacement fails
- Enhanced the `submitInternal` function to handle transaction replacement scenarios
- Extracted a reusable `BaseHeap` class from the existing heap implementation

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>