### PR TITLE
Remove transient variable workarounds and fix modifier order

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -184,22 +184,12 @@ paymaster-flamechart:
 ##@ Code Quality
 
 forge-fmt-check:
-	@# Temp workaround for forge fmt not supporting transient variables.
-	@# Tracked: https://github.com/foundry-rs/foundry/issues/9088
-	@sed -i.bak 's/transient private dispatchedExecutor;/private dispatchedExecutor;/' src/boop/happychain/HappyAccount.sol
 	@forge fmt --check src || true
-	@sed -i.bak 's/private dispatchedExecutor;/transient private dispatchedExecutor;/' src/boop/happychain/HappyAccount.sol
-	@rm src/boop/happychain/HappyAccount.sol.bak
 .PHONY: forge-fmt-check
 
 forge-fmt:
 	@biome check ./scripts --write;
-	@# Temp workaround for forge fmt not supporting transient variables.
-	@# Tracked: https://github.com/foundry-rs/foundry/issues/9088
-	@sed -i.bak 's/transient private dispatchedExecutor;/private dispatchedExecutor;/' src/boop/happychain/HappyAccount.sol
 	@forge fmt src || true
-	@sed -i.bak 's/private dispatchedExecutor;/transient private dispatchedExecutor;/' src/boop/happychain/HappyAccount.sol
-	@rm src/boop/happychain/HappyAccount.sol.bak
 .PHONY: forge-fmt
 
 solhint-check:
@@ -223,17 +213,7 @@ DOCS_OUT=docs/boop
 
 BOOP_SOL_FILES := $(shell find src/boop -type f -name '*.sol')
 
-patch-transient:
-	@sed -i.bak 's/transient private dispatchedExecutor;/private dispatchedExecutor;/' src/boop/happychain/HappyAccount.sol;
-	@rm -f src/boop/happychain/HappyAccount.sol.bak
-.PHONY: patch-transient
-
-unpatch-transient:
-	@sed -i.bak 's/address private dispatchedExecutor;/address transient private dispatchedExecutor;/' src/boop/happychain/HappyAccount.sol;
-	@rm -f src/boop/happychain/HappyAccount.sol.bak
-.PHONY: unpatch-transient
-
-patch-docs: patch-transient
+patch-docs:
 	@for file in $(BOOP_SOL_FILES); do \
 		cp $$file $$file.bak; bun run scripts/utils/postProcessDocLinks.ts $$file.bak > $$file; \
 	done
@@ -243,8 +223,6 @@ unpatch-docs:
 	@for file in $(BOOP_SOL_FILES); \
 		do if [ -f $$file.bak ]; then mv $$file.bak $$file; fi;  \
 	done
-	@make unpatch-transient; # after or the loop will overwrite it
-	@rm -f src/boop/happychain/HappyAccount.sol.bak
 .PHONY: unpatch-docs
 
 # Note on traps: EXIT doesn't catch ctrl+c, but using INT EXIT makes the trap trigger twice on ctrl+c (the

--- a/contracts/src/boop/happychain/HappyAccount.sol
+++ b/contracts/src/boop/happychain/HappyAccount.sol
@@ -44,7 +44,7 @@ contract HappyAccount is IExtensibleAccount, OwnableUpgradeable {
     mapping(ExtensionType => mapping(address => bool)) public extensions;
 
     /// Custom executor that was dispatched to during this transaction.
-    address transient private dispatchedExecutor;
+    address private transient dispatchedExecutor;
 
     // ====================================================================================================
     // MODIFIERS


### PR DESCRIPTION
### Linked Issues

- closes NOISSUE

### Description

Fixes the `transient` keyword order in `HappyAccount.sol` and removes the workarounds in the Makefile that were previously needed to handle forge fmt's lack of support for transient variables.

The PR:
1. Changes `address transient private dispatchedExecutor` to `address private transient dispatchedExecutor` in HappyAccount.sol
2. Removes all the temporary workarounds in the Makefile that were patching/unpatching the transient keyword during formatting operations
3. Simplifies the documentation generation process by removing the transient-specific patching steps

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>