### PR TITLE
Strip quotes from verifier flags and URLs in Makefile

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -336,9 +336,10 @@ kill-anvil: ## Kill an existing Anvil process running at $ANVIL_PORT
 ####################################################################################################
 ##@ Deployment
 
+strip_quotes = $(shell echo $(1) | sed -e 's/^["'\'']//; s/["'\'']$$//')
 VERIFY_FLAG := $(if $(findstring true,$(VERIFY_$(CONFIG))),--verify,)
-VERIFIER_FLAG := $(if $(findstring true,$(VERIFY_$(CONFIG))),$(VERIFIER_FLAG_$(CONFIG)),)
-VERIFIER_URL := $(if $(findstring true,$(VERIFY_$(CONFIG))),$(VERIFIER_URL_$(CONFIG)),)
+VERIFIER_FLAG := $(if $(findstring true,$(VERIFY_$(CONFIG))),$(call strip_quotes,$(VERIFIER_FLAG_$(CONFIG))),)
+VERIFIER_URL := $(if $(findstring true,$(VERIFY_$(CONFIG))),$(call strip_quotes,$(VERIFIER_URL_$(CONFIG))),)
 CHECK_UPGRADE := true
 
 ifeq ($(DEPLOY),deploy)


### PR DESCRIPTION
### Description

Fixed an issue in the Makefile where quotes in `VERIFIER_FLAG` and `VERIFIER_URL` variables weren't being properly stripped. Added a `strip_quotes` function that removes both single and double quotes from the beginning and end of strings, ensuring proper handling of verification parameters during contract deployment.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>