### PR TITLE
fix injected wallet icon contrast in dark mode

### DIFF
--- a/.changeset/public-nights-warn.md
+++ b/.changeset/public-nights-warn.md
@@ -1,0 +1,5 @@
+---
+"@happy.tech/iframe": patch
+---
+
+Fix wallet icon color on dark mode (invert color).

--- a/apps/iframe/src/components/ConnectModal.tsx
+++ b/apps/iframe/src/components/ConnectModal.tsx
@@ -146,7 +146,11 @@ const LoginPending = ({ provider }: { provider?: ConnectionProvider }) => {
             <div className="flex items-center justify-center gap-4">
                 <img alt="HappyChain Logo" src={"/images/happychainLogoSimple.png"} className="h-10" />
                 <DotLinearMotionBlurLoader />
-                <img className="h-8" src={provider?.icon} alt={`${provider?.name} icon`} />
+                <img
+                    className={cx("h-8", provider?.id === "injected:wallet.injected" && "dark:invert")}
+                    src={provider?.icon}
+                    alt={`${provider?.name} icon`}
+                />
             </div>
             <div className="text-center flex items-center justify-center">
                 Verify your {provider?.name} account to continue with HappyChain.

--- a/apps/iframe/src/components/interface/GlobalHeader.tsx
+++ b/apps/iframe/src/components/interface/GlobalHeader.tsx
@@ -1,6 +1,5 @@
 import { Msgs } from "@happy.tech/wallet-common"
-import { ArrowLeft, ArrowsInSimple } from "@phosphor-icons/react"
-import { GearSix } from "@phosphor-icons/react/dist/ssr"
+import { ArrowLeftIcon, ArrowsInSimpleIcon, GearSixIcon } from "@phosphor-icons/react"
 import { Link, useLocation } from "@tanstack/react-router"
 import { useAtom } from "jotai"
 import { appMessageBus } from "#src/services/eventBus"
@@ -18,7 +17,10 @@ const GlobalHeader = () => {
         <div className="relative max-w-prose mx-auto items-center w-full py-3 hidden lg:flex">
             {location.pathname !== "/embed" && (
                 <Link to={"/embed"}>
-                    <ArrowLeft weight="bold" className="text-base-content absolute start-2 top-1/2 -translate-y-1/2" />
+                    <ArrowLeftIcon
+                        weight="bold"
+                        className="text-base-content absolute start-2 top-1/2 -translate-y-1/2"
+                    />
                 </Link>
             )}
 
@@ -38,7 +40,7 @@ const GlobalHeader = () => {
                         if (!isVisible) setVisibility(true)
                     }}
                 >
-                    <GearSix weight="bold" />
+                    <GearSixIcon weight="bold" />
                 </button>
                 <button
                     title="Hide wallet"
@@ -47,7 +49,7 @@ const GlobalHeader = () => {
                     className="dark:opacity-60"
                     onClick={signalClosed}
                 >
-                    <ArrowsInSimple weight="bold" />
+                    <ArrowsInSimpleIcon weight="bold" />
                 </button>
             </div>
         </div>


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-580/dark-mode-injected-wallet-logo-color-on-connection-page

### Description

This PR fixes the wallet icon color in dark mode by adding an invert filter specifically for the injected wallet icon. The icon was difficult to see in dark mode, so this change ensures proper visibility by inverting its color when in dark theme.

Additionally, updated icon imports from Phosphor Icons to use the proper naming convention (using Icon suffix) for better consistency. (previous imports have been deprecated)

![Screenshot 2025-05-27 at 8.35.09 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/04qKkliMuuwaKjPzfrYQ/0aa6c58b-97a7-4571-a9c5-f6987c471d91.png)





<details close>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>