### PR TITLE
fix: refetch token balances when wallet is opened

### DIFF
--- a/.changeset/yellow-beers-smoke.md
+++ b/.changeset/yellow-beers-smoke.md
@@ -1,0 +1,5 @@
+---
+"@happy.tech/iframe": patch
+---
+
+Fix to refetch token balances when wallet is opened.


### PR DESCRIPTION
### Linked Issues
→ closes https://linear.app/happychain/issue/HAPPY-449/watched-assets-balances-never-update-after-mint

### Description

Fix token balance refetching when the wallet is opened. This PR adds functionality to refresh token balances when a user opens their wallet, ensuring they always see up-to-date balances.

The implementation:
- Accesses an atom to track when the wallet is opened
- Uses the `refetch` function from `useERC20Balance` to refresh token data
- Updates the balance formatting to use the token value directly

To test: 
- open the wallet w/ MTA token (import if not done already)
- close the wallet, then mint yourself a token or a few from [here](https://explorer.testnet.happy.tech/address/0x02206faC6469B2f59FC2Bb9d3BC181Fbe703F8B7?tab=write_contract#0x40c10f19).
- open the wallet to a new balance.

<details closed>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>