### PR TITLE
Reset chains when disconnecting wallet

### DIFF
--- a/apps/iframe/src/actions/setUserWithProvider.ts
+++ b/apps/iframe/src/actions/setUserWithProvider.ts
@@ -2,6 +2,7 @@ import type { HappyUser } from "@happy.tech/wallet-common"
 import { AuthState } from "@happy.tech/wallet-common"
 import { getDefaultStore } from "jotai"
 import type { EIP1193Provider } from "viem"
+import { resetChainsAtom } from "#src/state/chains.ts"
 import { connectWagmi, disconnectWagmi } from "#src/wagmi/utils"
 import { authStateAtom } from "../state/authState"
 import { providerAtom } from "../state/provider"
@@ -22,7 +23,10 @@ export async function setUserWithProvider(user: HappyUser, provider: EIP1193Prov
 export async function setUserWithProvider(user: HappyUser | undefined, provider: EIP1193Provider | undefined) {
     const isConnecting = Boolean(user && provider)
 
-    if (!isConnecting) await disconnectWagmi()
+    if (!isConnecting) {
+        await disconnectWagmi()
+        resetChainsAtom()
+    }
 
     store.set(providerAtom, provider)
     store.set(userAtom, user)

--- a/apps/iframe/src/constants/contracts.ts
+++ b/apps/iframe/src/constants/contracts.ts
@@ -11,7 +11,7 @@ import { type Address, isAddressEqual } from "viem"
 // works with other chains, but they will need to have the exact same contract deployment (addresses & ABIs).
 const chainId = Number(import.meta.env.VITE_CHAIN_ID)
 
-// Only used for chainId === 217 (HappyChain Sepolia).
+// Only used for chainId === 216 (HappyChain Sepolia).
 const useStagingContracts =
     import.meta.env.VITE_USE_STAGING_CONTRACTS === "true" || import.meta.env.VITE_USE_STAGING_CONTRACTS === "1"
 

--- a/apps/iframe/src/state/chains.ts
+++ b/apps/iframe/src/state/chains.ts
@@ -29,6 +29,10 @@ export const chainsAtom = atomWithStorage<
     Record<string, AddEthereumChainParameter> //
 >(StorageKey.Chains, getDefaultChainsRecord(), undefined, { getOnInit: true })
 
+export function resetChainsAtom() {
+    setChains(getDefaultChainsRecord())
+}
+
 export const {
     /** See {@link chainsAtom} */
     getValue: getChains,


### PR DESCRIPTION
### Description

This PR fixes an issue where chain information wasn't being properly reset when disconnecting a user. It adds a `resetChainsAtom` function to properly clear chain data during disconnection, ensuring a clean state for subsequent connections.

Additionally, it corrects a comment in the contracts.ts file, changing the referenced chainId from 217 to 216 for HappyChain Sepolia.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>