### PR TITLE
Fix Firefox scrollbar styling and improve UI elements

### DIFF
--- a/apps/iframe/src/components/interface/permissions/ListAppsWithPermissions.tsx
+++ b/apps/iframe/src/components/interface/permissions/ListAppsWithPermissions.tsx
@@ -13,10 +13,10 @@ const ListItem = ({ appURL }: ListItemProps) => {
 
     return (
         <li className="p-2 min-h-10 flex hover:bg-accent/10 [&:focus-within_[data-part=icon]]:bg-accent/10 font-medium relative overflow-hidden text-ellipsis items-center text-sm">
-            <span className="inline-flex gap-2 w-full max-w-prose mx-auto">
+            <span className="inline-flex items-center gap-2 w-full max-w-prose mx-auto">
                 <img
                     alt={appURL}
-                    className="text-transparent rounded-full h-[1.3rem] w-[1.5rem]"
+                    className="text-transparent rounded-full h-[1.5rem] w-[1.5rem] object-contain"
                     loading="lazy"
                     width="20"
                     height="20"
@@ -50,7 +50,7 @@ interface ListDappsWithPermissionsProps {
 export const ListAppsWithPermissions = ({ items }: ListDappsWithPermissionsProps) => {
     if (items.length === 0)
         return (
-            <p className="text-sm italic px-2 text-center py-24 w-10/12 mx-auto text-neutral/50">
+            <p className="text-sm italic px-2 text-center py-24 w-10/12 mx-auto text-content">
                 {" "}
                 It seems there aren't any apps you gave permissions to.
             </p>

--- a/apps/iframe/src/components/primitives/popover/variants.ts
+++ b/apps/iframe/src/components/primitives/popover/variants.ts
@@ -38,7 +38,8 @@ const recipeContent = cva(
                 modal: "motion-safe:[&[data-state=open]_[data-part=wrapper]]:animate-growIn motion-safe:[&[data-state=closed]_[data-part=wrapper]]:animate-growOut",
             },
             intent: {
-                default: "bg-base-100",
+                // needs extra ff-scrollbar-padding fix due to position 'absolute' of the popover
+                default: "bg-base-200 ff-scrollbar-px",
             },
             scale: {
                 default: "text-sm",

--- a/apps/iframe/src/routes/embed.lazy.tsx
+++ b/apps/iframe/src/routes/embed.lazy.tsx
@@ -89,7 +89,7 @@ function Embed() {
                 <BannerList />
                 <section
                     ref={scrollableSectionRef}
-                    className="relative grid min-h-0 h-full gap-4 overflow-y-auto scrollbar-stable scrollbar-thin auto-rows-[1fr] has-[.lock-parent-scroll[data-state=open]]:overflow-hidden"
+                    className="relative grid min-h-0 h-full gap-4 overflow-y-auto scrollbar-stable scrollbar-thin auto-rows-[1fr] has-[.lock-parent-scroll[data-state=open]]:overflow-hidden bg-base-200"
                 >
                     <Outlet />
                     {!location.pathname.includes("permissions") && (

--- a/apps/iframe/src/routes/embed/permissions.$appURL.lazy.tsx
+++ b/apps/iframe/src/routes/embed/permissions.$appURL.lazy.tsx
@@ -24,7 +24,7 @@ function DappPermissions() {
     //      and then adds new permissions. Not a huge priority, granting permissions is rare.
 
     return (
-        <div className="bg-base-100 pb-14 overflow-x-hidden">
+        <div className="pb-14 overflow-x-hidden">
             <div className="animate-appear">
                 <h2 className="sticky top-0 text-center bg-base-200 text-base-content font-bold p-1 text-sm">
                     {appURL}

--- a/apps/iframe/src/routes/embed/permissions.index.lazy.tsx
+++ b/apps/iframe/src/routes/embed/permissions.index.lazy.tsx
@@ -12,7 +12,7 @@ function Permissions() {
 
     return (
         <>
-            <div className="bg-base-100 pb-14 relative">
+            <div className="pb-14 relative">
                 <h2 className="sticky z-10 top-0 text-center bg-base-200 text-base-content font-bold p-1 text-sm">
                     Permissions
                 </h2>

--- a/apps/iframe/src/styles/tailwind.css
+++ b/apps/iframe/src/styles/tailwind.css
@@ -3,9 +3,52 @@
 @tailwind utilities;
 
 @layer base {
+    /**
+     * Firefox doesn't add padding to scrollbarGutter: "stable both-edges"
+     * So here we will simply add padding ourselves. This only works since
+     * firefox also does not support the `overlay` value for scrollbarGutter.
+     *
+     * spacing values should match .scrollbar-thin::-webkit-scrollbar in tailwind.config.ts
+     */
+    :root {
+        --tailwind-scrollbar-width: 10px;
+    }
+
     @font-face {
         font-family: "Inter", sans-serif;
         font-optical-sizing: auto;
         font-style: normal;
+    }
+}
+
+/* biome-ignore lint/correctness/noUnknownProperty: its available on chrome, not firefox */
+@supports (not (overlay: none)) {
+    .overflow-y-auto.scrollbar-stable {
+        padding-left: var(--tailwind-scrollbar-width);
+        padding-right: var(--tailwind-scrollbar-width);
+    }
+    .overflow-x-auto.scrollbar-stable {
+        padding-top: var(--tailwind-scrollbar-width);
+        padding-bottom: var(--tailwind-scrollbar-width);
+    }
+    .overflow-auto.scrollbar-stable {
+        padding: var(--tailwind-scrollbar-width);
+    }
+
+    .ff-scrollbar-py {
+        padding-top: var(--tailwind-scrollbar-width);
+        padding-bottom: var(--tailwind-scrollbar-width);
+    }
+
+    .ff-scrollbar-px {
+        padding-left: var(--tailwind-scrollbar-width);
+        padding-right: var(--tailwind-scrollbar-width);
+    }
+
+    .ff-scrollbar-p {
+        padding-left: var(--tailwind-scrollbar-width);
+        padding-right: var(--tailwind-scrollbar-width);
+        padding-top: var(--tailwind-scrollbar-width);
+        padding-bottom: var(--tailwind-scrollbar-width);
     }
 }

--- a/apps/iframe/tailwind.config.ts
+++ b/apps/iframe/tailwind.config.ts
@@ -155,6 +155,7 @@ export default {
                     scrollbarColor: "rgba(100, 100, 100, 0.5) transparent",
                 },
                 ".scrollbar-thin::-webkit-scrollbar": {
+                    // If these change, be sure to match the firefox fix in tailwind.css
                     width: "6px",
                     height: "6px",
                 },


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR improves the UI for the permissions section in the iframe app with several visual enhancements:

- Fixed Firefox scrollbar issues by adding custom CSS utilities (`ff-scrollbar-px`, `ff-scrollbar-py`, `ff-scrollbar-p`) to ensure consistent padding across browsers
- Improved app icon display in the permissions list by adding `object-contain` and adjusting dimensions
- Enhanced the empty permissions state text color for better readability
- Updated background colors in the permissions section for better visual consistency
- Added proper vertical alignment for app icons in the permissions list

These changes ensure a more consistent user experience across different browsers, particularly Firefox, which handles scrollbars differently than other browsers.

---

spacing repro: https://codepen.io/not-reed/pen/gbpwvYr (open in firefox and chrome)

### Before

| Chrome       | Firefox           |
| ------------- |:-------------:| 
| ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/f349dfac-9351-4fc9-9f93-b066d1732d23.png)      | ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/7ceaac92-88dc-4f60-8d51-ab06e0790a96.png) |
| ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/33b0f6bf-6f08-40f6-9b1f-1f3eff411649.png) | ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/78e35691-3338-4800-a475-9b870ba5e1d0.png) | 

### After

| Chrome        | Firefox           |
| ------------- |:-------------:| 
| ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/5774716d-b384-4678-80f5-7461472a7b3b.png) | ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/3c9edcdb-89c2-42d9-be37-447228c47c9c.png) |
| ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/51a2c376-1cf0-4ac8-86de-8143e2bdcf23.png) | ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7GxxSQZDiZzbUkW3hQVs/9b1771cd-131e-45b0-aae0-f989aaceeb17.png) | 


<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>