### PR TITLE
extend support for wallet_sendTransaction in iframe

### DIFF
--- a/.changeset/tame-actors-start.md
+++ b/.changeset/tame-actors-start.md
@@ -1,0 +1,6 @@
+---
+"@happy.tech/iframe": minor
+"@happy.tech/wallet-common": patch
+---
+
+Add support for wallet_sendTransaction RPC request.

--- a/apps/iframe/src/components/requests/EthSendTransaction.tsx
+++ b/apps/iframe/src/components/requests/EthSendTransaction.tsx
@@ -31,7 +31,7 @@ export const EthSendTransaction = ({
     params,
     reject,
     accept,
-}: RequestConfirmationProps<"eth_sendTransaction">) => {
+}: RequestConfirmationProps<"eth_sendTransaction" | "wallet_sendTransaction">) => {
     const tx = params[0]
 
     const user = useAtomValue(userAtom)

--- a/apps/iframe/src/constants/requestLabels.ts
+++ b/apps/iframe/src/constants/requestLabels.ts
@@ -4,6 +4,7 @@ import { Permissions } from "./permissions"
 export const requestLabels = {
     eth_requestAccounts: "Connect",
     eth_sendTransaction: "Send transaction",
+    wallet_sendTransaction: "Send transaction",
     personal_sign: "Sign message",
     wallet_addEthereumChain: "Add chain",
     wallet_requestPermissions: "Grant permissions",

--- a/apps/iframe/src/requests/handlers/approved.ts
+++ b/apps/iframe/src/requests/handlers/approved.ts
@@ -24,6 +24,7 @@ export async function dispatchApprovedRequest(request: PopupMsgs[Msgs.PopupAppro
     }
 
     switch (request.payload.method) {
+        case "wallet_sendTransaction":
         case "eth_sendTransaction": {
             const tx = checkedTx(request.payload.params[0])
             return await sendBoop({

--- a/apps/iframe/src/requests/handlers/injected.ts
+++ b/apps/iframe/src/requests/handlers/injected.ts
@@ -67,6 +67,7 @@ export async function dispatchInjectedRequest(request: ProviderMsgsFromApp[Msgs.
             return await sendToPublicClient(app, request.payload)
         }
 
+        case "wallet_sendTransaction":
         case "eth_sendTransaction": {
             checkUser(user)
             const tx = checkedTx(request.payload.params[0])

--- a/apps/iframe/src/requests/handlers/permissionless.ts
+++ b/apps/iframe/src/requests/handlers/permissionless.ts
@@ -33,6 +33,7 @@ export async function dispatchedPermissionlessRequest(request: ProviderMsgsFromA
             return getCurrentChain().chainId
         }
 
+        case "wallet_sendTransaction":
         case "eth_sendTransaction": {
             // A permissionless transaction is always a session key transaction!
             const tx = checkedTx(request.payload.params[0])

--- a/apps/iframe/src/routes/request.lazy.tsx
+++ b/apps/iframe/src/routes/request.lazy.tsx
@@ -121,6 +121,7 @@ function Request() {
     switch (req.method as keyof typeof requestLabels) {
         case "personal_sign":
             return <PersonalSign {...props} />
+        case "wallet_sendTransaction":
         case "eth_sendTransaction":
             return <EthSendTransaction {...props} />
         case "wallet_switchEthereumChain":

--- a/apps/iframe/src/utils/checkIfRequestRequiresConfirmation.ts
+++ b/apps/iframe/src/utils/checkIfRequestRequiresConfirmation.ts
@@ -27,7 +27,7 @@ export function checkIfRequestRequiresConfirmation(
 
     switch (payload.method) {
         // Users don't need to approve permissions that have already been granted.
-
+        case "wallet_sendTransaction":
         case "eth_sendTransaction":
             return !hasPermissions(app, {
                 [Permissions.SessionKey]: { target: payload.params[0].to },

--- a/support/wallet-common/lib/interfaces/events.ts
+++ b/support/wallet-common/lib/interfaces/events.ts
@@ -225,6 +225,7 @@ export type ProviderMsgsFromWallet = {
 
 type RequestExtraDataTypeMap = {
     eth_sendTransaction: SimulateSuccess
+    wallet_sendTransaction: SimulateSuccess
 }
 
 /**

--- a/support/wallet-common/lib/interfaces/permissions.ts
+++ b/support/wallet-common/lib/interfaces/permissions.ts
@@ -113,6 +113,7 @@ const unsafeList = new Set([
     // send transactions
     "eth_sendRawTransaction",
     "eth_sendTransaction",
+    "wallet_sendTransaction",
     // cryptography
     "eth_decrypt",
     "eth_getEncryptionPublicKey",


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-572/add-a-request-popup-for-wallet-sendtransaction-or-prevent-viem-from

### Description

< DESCRIPTION GOES HERE >

cf. issue description

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>
