### PR TITLE
Add SharedWorker heartbeat detection and improve web3auth disconnection

### DIFF
--- a/apps/iframe/src/connections/firebase/services/FirebaseConnector.ts
+++ b/apps/iframe/src/connections/firebase/services/FirebaseConnector.ts
@@ -94,6 +94,7 @@ export abstract class FirebaseConnector implements ConnectionProvider {
     public async disconnect() {
         try {
             await setFirebaseAuthState(FirebaseAuthState.Disconnecting)
+            // just do our best, it may fail
             await Promise.allSettled([firebaseAuth.signOut(), web3AuthDisconnect()])
             await this.onDisconnect()
             await setFirebaseAuthState(FirebaseAuthState.Disconnected)

--- a/apps/iframe/src/connections/firebase/workers/web3auth/polyfill.ts
+++ b/apps/iframe/src/connections/firebase/workers/web3auth/polyfill.ts
@@ -6,8 +6,9 @@
  */
 
 // supply window.Buffer functionality
-// biome-ignore lint/style/useNodejsImportProtocol: it's the npm module polyfill, not the NodeJS import
-import { Buffer } from "buffer"
+// Trailing slash is suggested here https://www.npmjs.com/package/buffer#usage
+// it differentiates between 'node_modules/buffer/' and 'node:buffer'
+import { Buffer } from "buffer/"
 globalThis.Buffer = globalThis.Buffer || Buffer
 
 // web3Auth uses global.XXX but global is not defined in the SharedWorker

--- a/apps/iframe/vite.config.ts
+++ b/apps/iframe/vite.config.ts
@@ -85,7 +85,7 @@ export default defineConfig(({ command, mode }) => {
  */
 function sharedWorkerChunkStrategy() {
     return (id: string) => {
-        if (id.includes("web3auth.polyfill") || id.includes("@web3auth") || id.includes("@toruslabs")) {
+        if (id.includes("polyfill") || id.includes("@web3auth") || id.includes("@toruslabs")) {
             return "worker-web3auth-chunk"
         }
         if (id.includes("worker/dist/runtime")) {

--- a/support/worker/src/plugin/codegen.ts
+++ b/support/worker/src/plugin/codegen.ts
@@ -24,7 +24,7 @@ export function clientCodeGen(code: string, id: string) {
         + 'import SharedWorker from "@okikio/sharedworker"\n'
         + `import { SharedWorkerClient } from "${pkg.name}/runtime"\n`
         + `const __worker__ = new SharedWorker(new URL(${stringId}, import.meta.url), ${options})\n`
-        + "const __client__ = new SharedWorkerClient(__worker__)\n"
+        + `const __client__ = new SharedWorkerClient(__worker__, ${options})\n`
         + "export const dispatch = __client__.dispatch.bind(__client__)\n"
         + "export const addMessageListener = __client__.addMessageListener.bind(__client__)\n"
         + `// ${pkg.name} ends\n`

--- a/support/worker/src/runtime/payload.ts
+++ b/support/worker/src/runtime/payload.ts
@@ -11,9 +11,10 @@ type BroadcastPayload = { command: "broadcast"; data: unknown }
 type RpcResponsePayload = { command: "rpcResponse"; data: RpcPayload }
 type RpcRequestPayload = { command: "rpcRequest"; data: RpcPayload }
 type ConsolePayload = { command: "console"; data: unknown[]; key: string }
-type PingPayload = { command: "ping" }
+type PingPayload = { ts: number; command: "ping" }
+type PongPayload = { ts: number; command: "pong" }
 
-export type ServerPayload = BroadcastPayload | DispatchPayload | RpcResponsePayload | ConsolePayload
+export type ServerPayload = BroadcastPayload | DispatchPayload | RpcResponsePayload | ConsolePayload | PongPayload
 export type ClientPayload = DispatchPayload | RpcRequestPayload | PingPayload
 
 export function makeRpcRequestPayload(id: string, name: string, args: unknown, isError = false): RpcRequestPayload {
@@ -63,6 +64,7 @@ export function makeConsolePayload(key: string, data: unknown[]): ConsolePayload
 
 export function makePingPayload(): PingPayload {
     return {
+        ts: Date.now(),
         command: "ping",
     }
 }
@@ -79,6 +81,7 @@ export function parseClientPayload(payload?: ClientPayload): ClientPayload | und
 }
 export function parseServerPayload(payload?: ServerPayload): ServerPayload | undefined {
     switch (payload?.command) {
+        case "pong":
         case "rpcResponse":
         case "broadcast":
         case "dispatch":

--- a/support/worker/src/runtime/server.ts
+++ b/support/worker/src/runtime/server.ts
@@ -72,9 +72,7 @@ export class SharedWorkerServer implements ServerInterface {
 
         // Indexed based function recovery so that when the code is minified, both sides of the RPC
         // service still match
-        for (const fn of filteredFns) {
-            this._functions.set(`__FUNC_${idx++}__`, fn)
-        }
+        for (const fn of filteredFns) this._functions.set(`__FUNC_${idx++}__`, fn)
 
         this.heartbeat()
         this.connect()
@@ -88,9 +86,7 @@ export class SharedWorkerServer implements ServerInterface {
         setInterval(() => {
             const now = Date.now()
             for (const [port, date] of this._ports) {
-                if (now - date >= 2000) {
-                    this._ports.delete(port)
-                }
+                if (now - date >= 2000) this._ports.delete(port)
             }
         }, 1000)
     }
@@ -153,7 +149,8 @@ export class SharedWorkerServer implements ServerInterface {
                     break
                 }
                 case "ping": {
-                    this._ports.set(port, Date.now())
+                    this._ports.set(port, payload.ts)
+                    port.postMessage({ ts: payload.ts, command: "pong" })
                     break
                 }
                 default: {


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR improves the reliability of the SharedWorker communication system and fixes issues with web3auth disconnection:

- Added error handling for web3auth disconnection with a comment indicating we should do our best but it may fail
- Fixed the buffer import in the web3auth polyfill to use the correct path format
- Updated the SharedWorkerClient to detect when a worker appears dead or inaccessible
- Implemented a ping/pong heartbeat mechanism to monitor worker health
- Added timeout detection for RPC calls to prevent hanging when workers are unresponsive
- Improved the worker chunk strategy to better handle polyfill files
- Enhanced error reporting with more descriptive messages when workers are unavailable

These changes make the system more resilient to worker failures and provide better feedback to users when issues occur.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>