### PR TITLE
Add request queue to handle multiple pending requests in popup

### DIFF
--- a/apps/iframe/src/components/requests/EthRequestAccounts.tsx
+++ b/apps/iframe/src/components/requests/EthRequestAccounts.tsx
@@ -3,6 +3,7 @@ import { Layout } from "./common/Layout"
 import type { RequestConfirmationProps } from "./props"
 
 export const EthRequestAccounts = ({
+    requestCount,
     method,
     params,
     reject,
@@ -12,6 +13,7 @@ export const EthRequestAccounts = ({
 
     return (
         <Layout
+            requestCount={requestCount}
             headline={
                 <>
                     <span className="text-primary">{appURL}</span>

--- a/apps/iframe/src/components/requests/EthSendTransaction.tsx
+++ b/apps/iframe/src/components/requests/EthSendTransaction.tsx
@@ -27,6 +27,7 @@ const MIN_DISPLAY_WEI = 100_000_000_000_000n // 0.0001 HAPPY
 const MIN_DISPLAY_STR = "0.0001"
 
 export const EthSendTransaction = ({
+    requestCount,
     method,
     params,
     reject,
@@ -102,6 +103,7 @@ export const EthSendTransaction = ({
     return (
         <>
             <Layout
+                requestCount={requestCount}
                 headline="Confirm transaction"
                 actions={{
                     accept: {

--- a/apps/iframe/src/components/requests/HappyLoadAbi.tsx
+++ b/apps/iframe/src/components/requests/HappyLoadAbi.tsx
@@ -13,7 +13,9 @@ import {
     SubsectionTitle,
 } from "./common/Layout"
 import type { RequestConfirmationProps } from "./props"
+
 export const HappyLoadAbi = ({
+    requestCount,
     method,
     params,
     reject,
@@ -28,6 +30,7 @@ export const HappyLoadAbi = ({
 
     return (
         <Layout
+            requestCount={requestCount}
             headline={<>Import contract interface</>}
             description={
                 <>

--- a/apps/iframe/src/components/requests/HappyRequestSessionKey.tsx
+++ b/apps/iframe/src/components/requests/HappyRequestSessionKey.tsx
@@ -13,6 +13,7 @@ import {
 import type { RequestConfirmationProps } from "./props"
 
 export const HappyRequestSessionKey = ({
+    requestCount,
     method,
     params,
     reject,
@@ -23,6 +24,7 @@ export const HappyRequestSessionKey = ({
 
     return (
         <Layout
+            requestCount={requestCount}
             headline={<>Enable automatic approvals</>}
             description={
                 <div className="mb-4">

--- a/apps/iframe/src/components/requests/PersonalSign.tsx
+++ b/apps/iframe/src/components/requests/PersonalSign.tsx
@@ -10,13 +10,20 @@ import {
 } from "./common/Layout"
 import type { RequestConfirmationProps } from "./props"
 
-export const PersonalSign = ({ method, params, reject, accept }: RequestConfirmationProps<"personal_sign">) => {
+export const PersonalSign = ({
+    requestCount,
+    method,
+    params,
+    reject,
+    accept,
+}: RequestConfirmationProps<"personal_sign">) => {
     const formattedSignPayload = useMemo(() => {
         return hexToString(params[0])
     }, [params])
 
     return (
         <Layout
+            requestCount={requestCount}
             headline="Sign message"
             description={
                 <p className="mb-4">

--- a/apps/iframe/src/components/requests/UnknownRequest.tsx
+++ b/apps/iframe/src/components/requests/UnknownRequest.tsx
@@ -2,14 +2,20 @@ import { DisclosureSection } from "./common/DisclosureSection"
 import { FormattedDetailsLine, Layout, SectionBlock, SubsectionBlock, SubsectionContent } from "./common/Layout"
 
 interface UnknownRequestProps<T = unknown> {
+    requestCount: number
     method: string
     params: T
     reject: () => void
 }
 
-export const UnknownRequest = ({ method, params, reject }: UnknownRequestProps) => {
+export const UnknownRequest = ({ requestCount, method, params, reject }: UnknownRequestProps) => {
     return (
-        <Layout headline={method} description="" actions={{ reject: { children: "Go back", onClick: reject } }}>
+        <Layout
+            requestCount={requestCount}
+            headline={method}
+            description=""
+            actions={{ reject: { children: "Go back", onClick: reject } }}
+        >
             <SectionBlock>
                 <SubsectionBlock variant="error">
                     <SubsectionContent>

--- a/apps/iframe/src/components/requests/WalletAddEthereumChain.tsx
+++ b/apps/iframe/src/components/requests/WalletAddEthereumChain.tsx
@@ -11,6 +11,7 @@ import {
 import type { RequestConfirmationProps } from "./props"
 
 export const WalletAddEthereumChain = ({
+    requestCount,
     method,
     params,
     reject,
@@ -19,6 +20,7 @@ export const WalletAddEthereumChain = ({
     const [chain, setChain] = useState(params[0])
     return (
         <Layout
+            requestCount={requestCount}
             labelHeader="Add custom chain"
             headline="Add new chain"
             actions={{

--- a/apps/iframe/src/components/requests/WalletRequestPermissions.tsx
+++ b/apps/iframe/src/components/requests/WalletRequestPermissions.tsx
@@ -13,6 +13,7 @@ import {
 import type { RequestConfirmationProps } from "./props"
 
 export const WalletRequestPermissions = ({
+    requestCount,
     method,
     params,
     reject,
@@ -22,10 +23,19 @@ export const WalletRequestPermissions = ({
     const requestingMultiplePermissions = params.length > 1
 
     if (!requestingMultiplePermissions && "eth_accounts" in params[0])
-        return <EthRequestAccounts method={method} params={params} reject={reject} accept={accept} />
+        return (
+            <EthRequestAccounts
+                requestCount={requestCount}
+                method={method}
+                params={params}
+                reject={reject}
+                accept={accept}
+            />
+        )
 
     return (
         <Layout
+            requestCount={requestCount}
             headline={<>Grant new permission{requestingMultiplePermissions ? "s" : ""}</>}
             description={
                 <div className="mb-4">

--- a/apps/iframe/src/components/requests/WalletSwitchEthereumChain.tsx
+++ b/apps/iframe/src/components/requests/WalletSwitchEthereumChain.tsx
@@ -5,6 +5,7 @@ import { Layout } from "./common/Layout"
 import type { RequestConfirmationProps } from "./props"
 
 export const WalletSwitchEthereumChain = ({
+    requestCount,
     method,
     params,
     reject,
@@ -18,6 +19,7 @@ export const WalletSwitchEthereumChain = ({
     // biome-ignore format: save space
     if (import.meta.env.PROD)
         return <RequestDisabled
+                requestCount={requestCount}
                 headline={headline}
                 description="The Happy Wallet is an HappyChain exclusive 🤠"
                 reject={reject}
@@ -25,6 +27,7 @@ export const WalletSwitchEthereumChain = ({
 
     return (
         <Layout
+            requestCount={requestCount}
             headline={headline}
             description={
                 !chain ? (

--- a/apps/iframe/src/components/requests/WalletWatchAsset.tsx
+++ b/apps/iframe/src/components/requests/WalletWatchAsset.tsx
@@ -10,10 +10,17 @@ import {
 } from "./common/Layout"
 import type { RequestConfirmationProps } from "./props"
 
-export const WalletWatchAsset = ({ method, params, reject, accept }: RequestConfirmationProps<"wallet_watchAsset">) => {
+export const WalletWatchAsset = ({
+    requestCount,
+    method,
+    params,
+    reject,
+    accept,
+}: RequestConfirmationProps<"wallet_watchAsset">) => {
     const { type, options } = params
     return (
         <Layout
+            requestCount={requestCount}
             headline={`Add $${options.symbol} to your watch list`}
             description={
                 options.image && (

--- a/apps/iframe/src/components/requests/common/Layout.tsx
+++ b/apps/iframe/src/components/requests/common/Layout.tsx
@@ -9,6 +9,7 @@ import { userAtom } from "#src/state/user"
 import { getAppURL } from "#src/utils/appURL"
 
 interface LayoutProps extends PropsWithChildren {
+    requestCount: number
     labelHeader?: React.ReactNode
     headline?: React.ReactNode
     description?: React.ReactNode
@@ -18,7 +19,14 @@ interface LayoutProps extends PropsWithChildren {
     }
 }
 
-export const Layout = ({ labelHeader, headline, description, actions: { accept, reject }, children }: LayoutProps) => {
+export const Layout = ({
+    requestCount,
+    labelHeader,
+    headline,
+    description,
+    actions: { accept, reject },
+    children,
+}: LayoutProps) => {
     const user = useAtomValue(userAtom)
     const appURL = getAppURL()
     return (
@@ -26,6 +34,7 @@ export const Layout = ({ labelHeader, headline, description, actions: { accept, 
             <header className="w-full fixed z-10 bg-base-300 border-b border-neutral/10 dark:border-neutral/50 p-2 text-center font-bold text-xs">
                 <div className="mx-auto w-full max-w-prose">
                     <h1>{labelHeader ?? appURL}</h1>
+                    {requestCount ? <div>Pending: {requestCount}</div> : null}
                 </div>
             </header>
             <div className="pt-16">

--- a/apps/iframe/src/components/requests/common/RequestDisabled.tsx
+++ b/apps/iframe/src/components/requests/common/RequestDisabled.tsx
@@ -1,14 +1,16 @@
 import { Layout } from "./Layout"
 
 export type RequestDisabledProps = {
+    requestCount: number
     headline: string
     description?: string
     reject: () => void
 }
 
-export const RequestDisabled = ({ headline, description, reject }: RequestDisabledProps) => {
+export const RequestDisabled = ({ requestCount, headline, description, reject }: RequestDisabledProps) => {
     return (
         <Layout
+            requestCount={requestCount}
             headline={headline}
             description={description}
             actions={{

--- a/apps/iframe/src/components/requests/props.ts
+++ b/apps/iframe/src/components/requests/props.ts
@@ -10,6 +10,7 @@ export interface RequestConfirmationProps<
     TMethod extends keyof typeof requestLabels,
     TRequest extends Request<TMethod> = Request<TMethod>,
 > {
+    requestCount: number
     method: TRequest["method"]
     params: TRequest["params"]
     reject: () => void

--- a/apps/iframe/src/listeners/popupListenerBus.ts
+++ b/apps/iframe/src/listeners/popupListenerBus.ts
@@ -18,12 +18,12 @@ window.addEventListener("message", (msg) => {
     switch (msg.data.type) {
         case Msgs.PopupApprove: {
             handleApprovedRequest(msg.data.payload)
-            msg.source?.postMessage("request-close")
+            msg.source?.postMessage("request-end")
             return
         }
         case Msgs.PopupReject: {
             handleRejectedRequest(msg.data.payload)
-            msg.source?.postMessage("request-close")
+            msg.source?.postMessage("request-end")
             return
         }
     }


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR adds a request queue feature to the wallet popup, allowing multiple requests to be processed in sequence without opening multiple popup windows. When a dApp sends multiple requests, they are now queued and processed one after another in the same popup window.

https://www.loom.com/share/ce5e400453c74073bb1cb73e3bccc2f8

Key changes:
- Added a `requestCount` prop to all request components to display the number of pending requests
- Modified the popup window behavior to maintain a queue of requests
- Updated the request handling flow to navigate to the next request after completing the current one
- Changed message handling from `request-close` to `request-end` to better reflect the action
- Added UI indicator showing the number of pending requests in the popup header

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

Chrome, Firefox with Happy Wallet demo app

Tested scenarios:
- Single request flow
- Multiple sequential requests from dApp
- Rejecting requests in queue
- Approving requests in queue
- Window closing behavior after last request

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>