### PR TITLE
Fix asset balance display condition and update BalanceDisplay component logic

### DIFF
--- a/.changeset/hungry-zebras-buy.md
+++ b/.changeset/hungry-zebras-buy.md
@@ -1,0 +1,5 @@
+---
+"@happy.tech/iframe": patch
+---
+
+Fix condition for displaying a user's asset balance.

--- a/apps/iframe/src/components/interface/home/tabs/views/tokens/BalanceDisplay.tsx
+++ b/apps/iframe/src/components/interface/home/tabs/views/tokens/BalanceDisplay.tsx
@@ -14,7 +14,7 @@ interface BalanceDisplayProps {
  * @param truncatedBalance - Formatted balance string truncated to 4 decimal places, undefined if not available
  */
 const BalanceDisplay = ({ isLoading, balance }: BalanceDisplayProps) => {
-    if (isLoading && !balance) {
+    if (isLoading && balance !== undefined) {
         return <SpinnerIcon className="animate-spin" size="1.25em" />
     }
 

--- a/apps/iframe/src/components/interface/home/tabs/views/tokens/WatchedAsset.tsx
+++ b/apps/iframe/src/components/interface/home/tabs/views/tokens/WatchedAsset.tsx
@@ -1,7 +1,8 @@
+import type { Address } from "@happy.tech/common"
 import type { HappyUser } from "@happy.tech/wallet-common"
 import { useAtom } from "jotai"
 import { useEffect, useMemo, useState } from "react"
-import type { Address, WatchAssetParameters } from "viem"
+import type { WatchAssetParameters } from "viem"
 import { useERC20Balance } from "#src/hooks/useERC20Balance"
 import { walletOpenSignalAtom } from "#src/state/interfaceState.ts"
 import BalanceDisplay from "./BalanceDisplay"
@@ -26,8 +27,6 @@ const WatchedAsset = ({ user, asset }: WatchedAssetProps) => {
     const [isImageSourceBroken, setIsImageSourceBroken] = useState(false)
     const [walletOpenSignal, setWalletOpenSignal] = useAtom(walletOpenSignalAtom)
 
-    // type assertion(s) as Address here valid since before adding a token
-    // we check that the input string is an Address using the viem helper
     const { data: balanceData, isLoading, refetch } = useERC20Balance(tokenAddress as Address, userAddress)
 
     // shortened fields for UI visibility
@@ -35,8 +34,12 @@ const WatchedAsset = ({ user, asset }: WatchedAssetProps) => {
         () => (asset.options.symbol.length > 7 ? `${asset.options.symbol.slice(0, 7)}\u2026` : asset.options.symbol),
         [asset],
     )
+
     const truncatedBalance = useMemo(() => {
-        if (!balanceData?.value) return undefined
+        // here, we check with `value` since that's the fetched onchain data;
+        // we return `formatted` since that's intended for use within the UI
+        // in the BalanceDisplay component (using `value`)
+        if (balanceData?.value === undefined) return
 
         return new Intl.NumberFormat(navigator.language, {
             minimumFractionDigits: 2,


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-609/when-watching-a-token-and-having-zero-balance-a-warning-sign-is

### Description

Fixes condition which prevented the returned balance from being displayed.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>