### PR TITLE
fix padding for layouts in diff components in the wallet

### DIFF
--- a/.changeset/easy-jokes-fetch.md
+++ b/.changeset/easy-jokes-fetch.md
@@ -1,0 +1,5 @@
+---
+"@happy.tech/iframe": patch
+---
+
+Fix padding in various screens / components in the iframe.

--- a/apps/iframe/src/components/interface/GlobalHeader.tsx
+++ b/apps/iframe/src/components/interface/GlobalHeader.tsx
@@ -26,7 +26,7 @@ const GlobalHeader = () => {
             </span>
 
             {/* wallet options */}
-            <div className="flex flex-row gap-1 items-center absolute end-3 text-xl">
+            <div className="flex flex-row gap-2 items-center absolute end-3 text-xl">
                 <TriggerSecondaryActionsMenu />
 
                 <button

--- a/apps/iframe/src/components/interface/home/tabs/views/tokens/RemoveTokenMenu.tsx
+++ b/apps/iframe/src/components/interface/home/tabs/views/tokens/RemoveTokenMenu.tsx
@@ -29,7 +29,7 @@ const RemoveTokenMenu = ({ user, token }: RemoveTokensMenuProps) => {
                 >
                     <Menu.Item
                         asChild
-                        className="text-primary dark:text-content cursor-pointer p-2 bg-primary/20 hover:bg-primary/30 dark:bg-primary/10 dark:hover:bg-primary/20 rounded-md"
+                        className="text-primary dark:text-content cursor-pointer bg-primary/20 hover:bg-primary/30 dark:bg-primary/10 dark:hover:bg-primary/20 rounded-md p-1.5"
                         value={TokenMenuActions.StopTracking}
                         onClick={() => removeWatchedAsset(user, token)}
                     >

--- a/apps/iframe/src/components/interface/home/tabs/views/tokens/WatchedAsset.tsx
+++ b/apps/iframe/src/components/interface/home/tabs/views/tokens/WatchedAsset.tsx
@@ -69,25 +69,22 @@ const WatchedAsset = ({ user, asset }: WatchedAssetProps) => {
     return (
         <div
             key={`watched-asset-${tokenAddress}`}
-            className="rounded-xl inline-flex justify-between w-full min-h-10 max-w-full group overflow-x-hidden items-center gap-2 text-sm font-medium"
+            className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-2 min-h-10 p-2 text-sm font-medium"
         >
-            <div className="flex flex-row w-1/2 gap-1 items-center min-w-0 max-w-[50%]">
-                <img
-                    alt={tokenAddress}
-                    className="text-transparent rounded-full flex-shrink-0 size-4"
-                    loading="lazy"
-                    onError={() => setIsImageSourceBroken(true)}
-                    src={imageSource}
-                />
-                <span className="font-semibold text-sm whitespace-nowrap" title={asset.options.symbol}>
-                    {tokenSymbol}
-                </span>
-            </div>
+            <img
+                alt={tokenAddress}
+                className="text-transparent rounded-full flex-shrink-0 size-4"
+                loading="lazy"
+                onError={() => setIsImageSourceBroken(true)}
+                src={imageSource}
+            />
 
-            <div className="flex flex-row items-center w-1/2 justify-end min-w-0 space-x-1">
-                <BalanceDisplay isLoading={isLoading} balance={truncatedBalance} />
-                <RemoveTokenMenu user={userAddress} token={tokenAddress as Address} />
-            </div>
+            <span className="font-semibold text-sm truncate" title={asset.options.symbol}>
+                {tokenSymbol}
+            </span>
+
+            <BalanceDisplay isLoading={isLoading} balance={truncatedBalance} />
+            <RemoveTokenMenu user={userAddress} token={tokenAddress as Address} />
         </div>
     )
 }

--- a/apps/iframe/src/components/interface/menu-secondary-actions/SecondaryActionsMenu.tsx
+++ b/apps/iframe/src/components/interface/menu-secondary-actions/SecondaryActionsMenu.tsx
@@ -1,5 +1,12 @@
 import { Menu } from "@ark-ui/react/menu"
-import { CaretDownIcon, CaretRightIcon, CaretUpIcon } from "@phosphor-icons/react"
+import {
+    ArrowLeftIcon,
+    CaretDownIcon,
+    CaretRightIcon,
+    CaretUpIcon,
+    QueueIcon,
+    SignOutIcon,
+} from "@phosphor-icons/react"
 import { Link } from "@tanstack/react-router"
 import { cx } from "class-variance-authority"
 import { useAtom } from "jotai"
@@ -89,20 +96,29 @@ const SecondaryActionsMenu = () => {
                         }),
                     )}
                 >
-                    <div className="overflow-y-auto flex flex-col">
+                    <div className="overflow-y-auto flex flex-col px-2">
                         <Menu.Item asChild value={MenuActions.Permissions}>
                             <Link preload="intent" to="/embed/permissions">
                                 <span className="w-full max-w-prose mx-auto justify-between items-center inline-flex">
-                                    <span>Permissions</span>
+                                    <span className="flex items-center gap-2">
+                                        <QueueIcon size="1em" />
+                                        <span>Permissions</span>
+                                    </span>
                                     <CaretRightIcon size="1em" />
                                 </span>
                             </Link>
                         </Menu.Item>
                         <Menu.Item value={MenuActions.LogOut}>
-                            <span className="w-full max-w-prose mx-auto inline-flex">Logout</span>
+                            <span className="w-full max-w-prose mx-auto inline-flex items-center gap-2">
+                                <SignOutIcon size="1em" />
+                                <span>Logout</span>
+                            </span>
                         </Menu.Item>
                         <Menu.Item value={MenuActions.Back}>
-                            <span className="w-full max-w-prose mx-auto inline-flex">Go back</span>
+                            <span className="w-full max-w-prose mx-auto inline-flex items-center gap-2">
+                                <ArrowLeftIcon size="1em" />
+                                <span>Go back</span>
+                            </span>
                         </Menu.Item>
                     </div>
                 </Menu.Content>

--- a/apps/iframe/src/components/interface/permissions/ListAppsWithPermissions.tsx
+++ b/apps/iframe/src/components/interface/permissions/ListAppsWithPermissions.tsx
@@ -13,10 +13,10 @@ const ListItem = ({ appURL }: ListItemProps) => {
 
     return (
         <li className="p-2 min-h-10 flex hover:bg-accent/10 [&:focus-within_[data-part=icon]]:bg-accent/10 font-medium relative overflow-hidden text-ellipsis items-center text-sm">
-            <span className="inline-flex gap-2 w-full max-w-prose mx-auto">
+            <span className="inline-flex gap-2 w-full max-w-prose mx-auto items-center">
                 <img
                     alt={appURL}
-                    className="text-transparent rounded-full h-[1.3rem] w-[1.5rem]"
+                    className="text-transparent rounded-full size-[1.5rem]"
                     loading="lazy"
                     width="20"
                     height="20"

--- a/apps/iframe/src/routes/embed/permissions.$appURL.lazy.tsx
+++ b/apps/iframe/src/routes/embed/permissions.$appURL.lazy.tsx
@@ -24,7 +24,7 @@ function DappPermissions() {
     //      and then adds new permissions. Not a huge priority, granting permissions is rare.
 
     return (
-        <div className="bg-base-100 pb-14 overflow-x-hidden">
+        <div className="bg-base-100 pb-14 overflow-x-hidden px-1.5">
             <div className="animate-appear">
                 <h2 className="sticky top-0 text-center bg-base-200 text-base-content font-bold p-1 text-sm">
                     {appURL}


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-608/review-padding

### Description

This PR fixes padding issues across various components in the iframe to improve UI consistency and appearance:

- Increased gap between wallet options in the GlobalHeader from 1 to 2
- Adjusted padding in the RemoveTokenMenu to 1.5px for better spacing
- Completely restructured the WatchedAsset component layout using CSS grid for better alignment and overflow handling
- Added icons to the SecondaryActionsMenu items for better visual cues
- Added padding to the SecondaryActionsMenu content for better spacing
- Fixed image sizing in the ListAppsWithPermissions component
- Added horizontal padding to the permissions page

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>