### PR TITLE
Add Inter font to iframe app

### DIFF
--- a/apps/iframe/index.html
+++ b/apps/iframe/index.html
@@ -6,6 +6,9 @@
   <link rel="icon" type="image/png" href="/images/happychainLogoSimple.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Happy Account</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,100..900&display=swap" rel="stylesheet">
   <script>
     const mql = window.matchMedia('(prefers-color-scheme: dark)')
     // set daisyUI darkmode if user prefers dark-theme

--- a/apps/iframe/src/styles/tailwind.css
+++ b/apps/iframe/src/styles/tailwind.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+    @font-face {
+        font-family: "Inter", sans-serif;
+        font-optical-sizing: auto;
+        font-style: normal;
+    }
+}

--- a/apps/iframe/tailwind.config.ts
+++ b/apps/iframe/tailwind.config.ts
@@ -1,5 +1,6 @@
 import daisyui from "daisyui"
 import type { Config } from "tailwindcss"
+import defaultTheme from "tailwindcss/defaultTheme"
 import plugin from "tailwindcss/plugin"
 
 export default {
@@ -11,6 +12,9 @@ export default {
             lg: { raw: "(min-height: 72px) and (min-width: 210px)" },
         },
         extend: {
+            fontFamily: {
+                sans: ["Inter", ...defaultTheme.fontFamily.sans],
+            },
             keyframes: {
                 hideScrollbar: {
                     from: { overflow: "hidden" },


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

Added Inter font to the iframe app for consistent typography across the application. This PR:

- Adds preconnect links to Google Fonts in the HTML head
- Imports the Inter font family with variable weight support
- Configures the font-face in the Tailwind CSS base layer
- Updates the Tailwind configuration to use Inter as the primary sans-serif font

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>