### PR TITLE
Rename VITE_ALLOWED_HOSTS to ALLOWED_HOSTS in environment files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,10 +578,10 @@ select-staging-contracts:
 
 # Sets the allowed hosts for Vite.
 select-allowed-hosts:
-	$(call update_env,apps/iframe/.env,VITE_ALLOWED_HOSTS,$(urls))
-	$(call update_env,demos/js/.env,VITE_ALLOWED_HOSTS,$(urls))
-	$(call update_env,demos/react/.env,VITE_ALLOWED_HOSTS,$(urls))
-	$(call update_env,demos/vue/.env,VITE_ALLOWED_HOSTS,$(urls))
+	$(call update_env,apps/iframe/.env,ALLOWED_HOSTS,$(urls))
+	$(call update_env,demos/js/.env,ALLOWED_HOSTS,$(urls))
+	$(call update_env,demos/react/.env,ALLOWED_HOSTS,$(urls))
+	$(call update_env,demos/vue/.env,ALLOWED_HOSTS,$(urls))
 .PHONY: select-allowed-hosts
 
 select-submitter-local:

--- a/apps/iframe/.env.example
+++ b/apps/iframe/.env.example
@@ -68,5 +68,5 @@ HAPPY_RPC_OVERRIDE=
 # If empty (default), everyone is allowed.
 # This can be used to safely expose a local service to the internet, our main use case being testing on mobile devices.
 # You can set this with `make select-allowed-hosts urls=<YOUR_URLS>` in the top-level Makefile.
-VITE_ALLOWED_HOSTS=
+ALLOWED_HOSTS=
 

--- a/demos/js/.env.example
+++ b/demos/js/.env.example
@@ -6,4 +6,4 @@ VITE_CHAIN_ID=216
 # If empty (default), everyone is allowed.
 # This can be used to safely expose a local service to the internet, our main use case being testing on mobile devices.
 # You can set this with `make select-allowed-hosts urls=<YOUR_URLS>` in the top-level Makefile.
-VITE_ALLOWED_HOSTS=
+ALLOWED_HOSTS=

--- a/demos/react/.env.example
+++ b/demos/react/.env.example
@@ -6,4 +6,4 @@ VITE_CHAIN_ID=216
 # If empty (default), everyone is allowed.
 # This can be used to safely expose a local service to the internet, our main use case being testing on mobile devices.
 # You can set this with `make select-allowed-hosts urls=<YOUR_URLS>` in the top-level Makefile.
-VITE_ALLOWED_HOSTS=
+ALLOWED_HOSTS=

--- a/demos/vue/.env.example
+++ b/demos/vue/.env.example
@@ -6,4 +6,4 @@ VITE_CHAIN_ID=216
 # If empty (default), everyone is allowed.
 # This can be used to safely expose a local service to the internet, our main use case being testing on mobile devices.
 # You can set this with `make select-allowed-hosts urls=<YOUR_URLS>` in the top-level Makefile.
-VITE_ALLOWED_HOSTS=
+ALLOWED_HOSTS=

--- a/support/configs/vite.config.ts
+++ b/support/configs/vite.config.ts
@@ -8,7 +8,7 @@ import { defineConfig, loadEnv } from "vite"
 // Comma-separated list of hosts (IP addresses or domains) which are allowed to access this service. (Optional)
 // If empty, everyone is allowed.
 // This can be used to safely expose a local service to the internet, our main use case being testing on mobile devices.
-const allowedHosts = import.meta.env?.VITE_ALLOWED_HOSTS?.split(", ").map((a: string) => a.trim())
+const allowedHosts = import.meta.env?.ALLOWED_HOSTS?.split(", ").map((a: string) => a.trim())
 if (allowedHosts?.length) console.log("\nVite Allowing access from hosts:", allowedHosts)
 const serverHostConfig = allowedHosts?.length ? { host: true, allowedHosts: allowedHosts } : {}
 


### PR DESCRIPTION
### Description

Renamed the environment variable `VITE_ALLOWED_HOSTS` to `ALLOWED_HOSTS` across all project files. This change affects the Makefile, environment example files for iframe and demo applications (JS, React, Vue), and the Vite configuration. The variable is used to control which hosts are allowed to access the service, primarily for testing on mobile devices.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>