### PR TITLE
Persist wallet constants across hot-reloads in iframe app

### DIFF
--- a/apps/iframe/src/utils/appURL.ts
+++ b/apps/iframe/src/utils/appURL.ts
@@ -3,19 +3,19 @@ import { type HTTPString, type UUID, createUUID } from "@happy.tech/common"
 export type AppURL = HTTPString & { _brand: "AppHTTPString" }
 
 /** The full url of the app that the wallet is embedded in. */
-const _appURL = location.ancestorOrigins?.[0] ?? document.referrer
+const _appURL = import.meta.hot?.data._appURL ?? location.ancestorOrigins?.[0] ?? document.referrer
 
 /** the origin of the app that the wallet is embedded in, or empty if not embedded */
-const _appOrigin = _appURL ? new URL(_appURL).origin : ""
+const _appOrigin = import.meta.hot?.data._appOrigin ?? (_appURL ? new URL(_appURL).origin : "")
 
 /** The url of the App the wallet is embedded in, or empty if not embedded. */
-const appURL = _appOrigin && _appOrigin !== location.origin ? _appOrigin : ""
+const appURL = import.meta.hot?.data.appURL ?? (_appOrigin && _appOrigin !== location.origin ? _appOrigin : "")
 
 /** ID passed to the iframe by the parent window (app). */
-export const _parentID = new URLSearchParams(window.location.search).get("windowId")
+export const _parentID = import.meta.hot?.data._parentID ?? new URLSearchParams(window.location.search).get("windowId")
 
 /** ID generated for this wallet (tied to a specific app). */
-const _walletID = createUUID()
+const _walletID = import.meta.hot?.data._walletID ?? createUUID()
 
 if (!isWallet(getAppURL()) && !_parentID) {
     console.warn("Embedded Wallet initialized without windowId")
@@ -82,4 +82,14 @@ export function appForSourceID(sourceID: UUID): AppURL | undefined {
     if (sourceID === _parentID) return getAppURL()
     if (sourceID === _walletID) return getWalletURL()
     return undefined
+}
+
+/** Persist constants across hot-reloads */
+if (import.meta.hot) {
+    import.meta.hot.data._parentID = _parentID
+    import.meta.hot.data._appURL = _appURL
+    import.meta.hot.data._appOrigin = _appOrigin
+    import.meta.hot.data.appURL = appURL
+    import.meta.hot.data._walletID = _walletID
+    import.meta.hot.accept()
 }


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

This PR adds support for hot module reloading (HMR) in the iframe app by persisting critical URL and ID values across hot reloads. Without these changes, hot reloading would cause the wallet to lose its connection context with the parent application.

The implementation uses Vite's `import.meta.hot` API to store and retrieve values like `appURL`, `_appOrigin`, `_parentID`, and `_walletID` between hot module replacements, ensuring a consistent state during development.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>