### PR TITLE
refactor back button to use history state

### DIFF
--- a/.changeset/ninety-groups-cross.md
+++ b/.changeset/ninety-groups-cross.md
@@ -1,0 +1,5 @@
+---
+"@happy.tech/iframe": patch
+---
+
+Update back button to go back in history state.

--- a/apps/iframe/src/components/interface/GlobalHeader.tsx
+++ b/apps/iframe/src/components/interface/GlobalHeader.tsx
@@ -1,24 +1,25 @@
 import { Msgs } from "@happy.tech/wallet-common"
 import { ArrowLeftIcon, ArrowsInSimpleIcon } from "@phosphor-icons/react"
-import { Link, useLocation } from "@tanstack/react-router"
+import { useRouter } from "@tanstack/react-router"
 import { appMessageBus } from "#src/services/eventBus"
 import { TriggerSecondaryActionsMenu } from "./menu-secondary-actions/SecondaryActionsMenu"
 
 function signalClosed() {
     void appMessageBus.emit(Msgs.WalletVisibility, { isOpen: false })
 }
+
 export const GlobalHeader = () => {
-    const location = useLocation()
+    const router = useRouter()
 
     return (
         <div className="relative max-w-prose mx-auto items-center w-full py-3 hidden lg:flex">
-            {location.pathname !== "/embed" && (
-                <Link to={"/embed"}>
+            {router.state.location.pathname !== "/embed" && (
+                <button type="button" onClick={() => router.history.back()} aria-label="Go back" title="Go back">
                     <ArrowLeftIcon
                         weight="bold"
                         className="text-base-content absolute start-2 top-1/2 -translate-y-1/2"
                     />
-                </Link>
+                </button>
             )}
 
             <span className="text-base-content text-sm font-bold mx-auto hidden lg:flex justify-center">


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-561/wallet-menus-ie-permissions-back-doesnt-behave-correctly

### Description

Updated the back button in the GlobalHeader component to use browser history navigation instead of a direct link to the embed page. This change allows users to navigate to their previous location rather than always returning to the embed page.

The implementation:
- Replaced the Link component with a button that calls `router.history.back()`
- Changed from using `useLocation` to `useRouter` to access history functionality
- Added appropriate accessibility attributes (aria-label and title) to the back button

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>