### PR TITLE
removed disabled prop from input fields in the import token dialog

### DIFF
--- a/.changeset/evil-boats-camp.md
+++ b/.changeset/evil-boats-camp.md
@@ -1,0 +1,5 @@
+---
+"@happy.tech/iframe": patch
+---
+
+Remove `disabled` prop from input fields in import token dialog.

--- a/apps/iframe/src/components/interface/home/tabs/views/tokens/ImportTokensDialog.tsx
+++ b/apps/iframe/src/components/interface/home/tabs/views/tokens/ImportTokensDialog.tsx
@@ -64,7 +64,10 @@ export const ImportTokensDialog = () => {
     // 1. Address is invalid OR
     // 2. We don't have either contract data or user input for both symbol and decimals
     const submitButtonDisabledCondition =
-        !isValidAddress || (symbol === undefined && customTokenSymbol === "") || decimals === undefined
+        !isValidAddress ||
+        (symbol === undefined && customTokenSymbol === "") ||
+        decimals === undefined ||
+        status === "pending"
 
     // Input field change handlers
     const handleAddressInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -188,14 +191,13 @@ export const ImportTokensDialog = () => {
                                 symbolInputInvalidCondition ||
                                 status === "pending"
                             }
-                            disabled
                         >
                             <FormField.Label>Token symbol</FormField.Label>
                             <FormField.Input
                                 name="symbol"
                                 value={customTokenSymbol}
                                 onChange={handleCustomSymbolInputChange}
-                                className="select-none pointer-events-none"
+                                className="select-none pointer-events-none outline-none focus:outline-none focus-visible:outline-none focus:ring-0 focus:shadow-none caret-transparent cursor-default"
                             />
                             <FormField.ErrorText>
                                 {/* Spacing */}
@@ -209,7 +211,7 @@ export const ImportTokensDialog = () => {
                          * - Shows decimals from contract if available
                          * - Defaults to "18" if contract read fails (most tokens use 18 decimals)
                          */}
-                        <FormField.Root required readOnly disabled>
+                        <FormField.Root required readOnly>
                             <FormField.Label className="text-md text-base-content disabled:opacity-50">
                                 Token decimals
                             </FormField.Label>
@@ -217,7 +219,7 @@ export const ImportTokensDialog = () => {
                                 value={decimals || ""}
                                 name="decimals"
                                 type="number"
-                                className="select-none pointer-events-none"
+                                className="select-none pointer-events-none outline-none focus:outline-none focus-visible:outline-none focus:ring-0 focus:shadow-none caret-transparent cursor-default"
                             />
                             <FormField.ErrorText>
                                 {/* Spacing */}
@@ -229,7 +231,7 @@ export const ImportTokensDialog = () => {
                             intent="primary"
                             className="text-neutral-content justify-center"
                             isLoading={status === "pending"}
-                            disabled={submitButtonDisabledCondition || status === "pending"}
+                            disabled={submitButtonDisabledCondition}
                         >
                             Submit
                         </Button>

--- a/apps/iframe/src/components/primitives/form-field/FormField.tsx
+++ b/apps/iframe/src/components/primitives/form-field/FormField.tsx
@@ -48,7 +48,7 @@ const HelperText = forwardRef<HTMLSpanElement, HelperTextProps>(({ className = "
 
 interface ErrorTextProps extends FieldErrorTextProps {}
 const ErrorText = forwardRef<HTMLSpanElement, ErrorTextProps>(({ className = "", children, ...props }, ref) => (
-    <span className="flex">
+    <span className="flex select-none">
         <ArkField.ErrorText
             ref={ref}
             className={cx("text-start text-error/80 text-[0.70rem] text-xs", className)}


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-615/fix-import-token

### Description

Improves the import token dialog by removing the `disabled` prop from input fields while maintaining their read-only appearance. This change:

- Removes the `disabled` attribute from symbol and decimals form fields
- Adds proper styling to maintain the read-only appearance with `cursor-default` and `caret-transparent`
- Updates the submit button's disabled condition to include the pending status check
- Makes the error text non-selectable with `select-none` class

These changes improve accessibility while maintaining the same visual appearance and behavior of the form.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>