### PR TITLE
Remove status and description fields from receipts table and related code

### DIFF
--- a/apps/submitter/lib/database/migrations/1746950606173_initialize.ts
+++ b/apps/submitter/lib/database/migrations/1746950606173_initialize.ts
@@ -29,7 +29,6 @@ export async function up(db: DB) {
         .createTable("receipts")
         .addColumn("boopHash", "text", (col) => col.primaryKey().notNull().references("boops.boopHash"))
         .addColumn("logs", "text", (col) => col.notNull())
-        .addColumn("revertData", "text", (col) => col.notNull())
         .addColumn("evmTxHash", "text", (col) => col.notNull())
         .addColumn("blockHash", "text", (col) => col.notNull())
         .addColumn("blockNumber", "text", (col) => col.notNull())

--- a/apps/submitter/lib/database/typeGenOverrides.ts
+++ b/apps/submitter/lib/database/typeGenOverrides.ts
@@ -21,10 +21,6 @@ export const overrides = {
         "boops.extraData": "Hex",
 
         "receipts.boopHash": "Hash",
-        "receipts.gasCost": "bigint",
-        "receipts.nonceTrack": "bigint",
-        "receipts.nonceValue": "bigint",
-        "receipts.revertData": "Hex",
         "receipts.evmTxHash": "Hash",
         "receipts.blockHash": "Hash",
         "receipts.blockNumber": "bigint",

--- a/apps/submitter/lib/handlers/execute/execute.spec.ts
+++ b/apps/submitter/lib/handlers/execute/execute.spec.ts
@@ -124,7 +124,6 @@ describe("submitter_execute", () => {
             expect(response.receipt.boopHash).toBeString()
             expect(response.receipt.entryPoint).toBeString()
 
-            expect(response.receipt.revertData).toBe("0x")
             expect(response.receipt.evmTxHash).toBeString()
             expect(response.receipt.blockHash).toBeString()
             expect(BigInt(response.receipt.blockNumber)).toBeGreaterThan(0n)

--- a/apps/submitter/lib/types/BoopReceipt.ts
+++ b/apps/submitter/lib/types/BoopReceipt.ts
@@ -17,11 +17,6 @@ export type BoopReceipt = {
     /** Logs (events) that were emitted during the call made by the boop. */
     logs: BoopLog[]
 
-    /**
-     * The revertData carried by one of our custom error, or the raw deal for {@link Onchain.UnexpectedReverted}.
-     */
-    revertData: Hex
-
     // TODO try to reintroduce these (and upddate docs to explain cost structure)
 
     // /** Gas used by the boop */

--- a/apps/submitter/lib/utils/validation/boop.ts
+++ b/apps/submitter/lib/utils/validation/boop.ts
@@ -33,7 +33,6 @@ export const SBoopReceipt = type({
     boop: SBoop,
     entryPoint: Address,
     logs: SBoopLog.array(),
-    revertData: Bytes,
     evmTxHash: Hash,
     blockHash: Hash,
     blockNumber: UInt256,


### PR DESCRIPTION
### Linked Issues

- closes [HAPPY-611](https://linear.app/happychain/issue/HAPPY-611/stop-storing-description-and-status-in-submitter-db)

### Description

Removed unnecessary fields from the `receipts` table and `BoopReceipt` type:
- Removed `status` and `description` columns from the database schema
- Updated type definitions and service code to reflect these changes
- Adjusted tests to no longer check for these removed fields

This simplifies the receipt structure by removing redundant status information that was already available through other means.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>