### PR TITLE
Use appropriate console methods for different log levels

### DIFF
--- a/support/common/lib/utils/logger.ts
+++ b/support/common/lib/utils/logger.ts
@@ -194,6 +194,23 @@ export class Logger {
             : `[${levelStr}] [${tagsStr}]`
     }
 
+    #getConsoleForLevel(level: LogLevel) {
+        switch (level) {
+            case LogLevel.OFF:
+                return () => {} // No-op for OFF level
+            case LogLevel.ERROR:
+                return console.error
+            case LogLevel.WARN:
+                return console.warn
+            case LogLevel.INFO:
+                return console.log
+            case LogLevel.TRACE:
+                return console.debug
+            default:
+                return console.log
+        }
+    }
+
     /**
      * Generic log function that logs a message at the specified log level.
      *
@@ -205,7 +222,8 @@ export class Logger {
         const tags = Array.isArray(tagOrTags) ? tagOrTags : [tagOrTags]
 
         if (this.shouldLog(level, tags)) {
-            console.log(this.getPrelude(level, tags), ...args)
+            const logger = this.#getConsoleForLevel(level)
+            logger(this.getPrelude(level, tags), ...args)
         }
     }
 


### PR DESCRIPTION
### Description

Enhanced the Logger class to use appropriate console methods based on log levels. Instead of using `console.log` for all log levels, the PR introduces a new private method `#getConsoleForLevel` that maps each log level to its corresponding console method:

- `LogLevel.ERROR` → `console.error`
- `LogLevel.WARN` → `console.warn`
- `LogLevel.INFO` → `console.log`
- `LogLevel.TRACE` → `console.debug`
- `LogLevel.OFF` → no-op function

This change improves log visibility in the console by using the appropriate styling and filtering capabilities provided by browser dev tools.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>