### PR TITLE
fix: add getBlock to subscription

### DIFF
--- a/apps/submitter/lib/env/schemas/tuning.ts
+++ b/apps/submitter/lib/env/schemas/tuning.ts
@@ -57,21 +57,12 @@ export const tuningSchema = z.object({
     BLOCK_MONITORING_TIMEOUT: z.coerce.number().positive().default(3000),
 
     /**
-     * When we hear that a block included an EVM transaction we sent, we fetch its receipts. The
-     * node might not immediately have the receipt available, so we try up to three times, with the
-     * first retry waiting for this delay (in milliseconds), and the second retry waiting twice
-     * the amount. The time for the attempt itself is not included (and could take up to {@link
-     * RPC_REQUEST_TIMEOUT}. Note that this will eat into receipt timeouts ({@link RECEIPT_TIMEOUT}).
-     *
-     * Defaults to 200.
+     * The time in milliseconds to wait before successive attempts to fetch a block
+     * or receipt from the RPC provider. The time for the attempt itself is not included (and could take up to {@link
+     * RPC_REQUEST_TIMEOUT}. Note: in the case of the receipt, this will eat into receipt timeouts ({@link RECEIPT_TIMEOUT}).
+     * Defaults to 100 ms.
      */
-    RECEIPT_RETRY_DELAY: z.coerce.number().positive().default(200),
-
-    /**
-     * The time in milliseconds to wait before successive attempts to fetch a block from the RPC
-     * Defaults to 20 ms.
-     */
-    BLOCK_RETRY_DELAY: z.coerce.number().positive().default(20),
+    LINEAR_RETRY_DELAY: z.coerce.number().positive().default(100),
 
     /**
      * The maximum number of blocks to backfill if block monitoring runs into a block

--- a/apps/submitter/lib/services/BlockService.ts
+++ b/apps/submitter/lib/services/BlockService.ts
@@ -314,7 +314,7 @@ export class BlockService {
                 })
                 break
             } catch {
-                await sleep(env.BLOCK_RETRY_DELAY * i)
+                await sleep(env.LINEAR_RETRY_DELAY * i)
             }
         }
         return block

--- a/apps/submitter/lib/services/EvmReceiptService.ts
+++ b/apps/submitter/lib/services/EvmReceiptService.ts
@@ -77,7 +77,7 @@ export class EvmReceiptService {
                 receipt = await publicClient.getTransactionReceipt({ hash: evmTxHash })
                 break
             } catch {
-                await sleep(env.RECEIPT_RETRY_DELAY * i)
+                await sleep(env.LINEAR_RETRY_DELAY * i)
             }
         return receipt
     }


### PR DESCRIPTION
### Description

Enhances block handling in the BlockService by adding retry logic when fetching blocks. The changes:

- Adds error handling for malformed block data
- Implements a retry mechanism (up to 3 attempts) when fetching a block fails
- Uses `getBlock` to fetch the block with transaction hashes instead of directly using the data from the subscription
- Adds a 20ms delay between retry attempts
- Adds a placeholder `#getBlock` method for future implementation

These changes improve reliability when processing new blocks, especially in cases where the block data might not be immediately available after receiving the notification.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>