### PR TITLE
rename BadgeProps to ConnectButtonProps

### DIFF
--- a/.changeset/sharp-dots-stick.md
+++ b/.changeset/sharp-dots-stick.md
@@ -1,0 +1,6 @@
+---
+"@happy.tech/react": patch
+"@happy.tech/core": patch
+---
+
+Rename BadgeProps to ConnectButtonProps.

--- a/packages/core/lib/badge/badge.tsx
+++ b/packages/core/lib/badge/badge.tsx
@@ -7,9 +7,9 @@ import badgeStyles from "./styles/badge.css?inline"
 import propertyStyles from "./styles/property.css?inline"
 import { useConnection } from "./useConnection"
 
-export type BadgeProps = { disableStyles?: boolean | string }
+export type ConnectButtonProps = { disableStyles?: boolean | string }
 
-export function Badge({ disableStyles = false }: BadgeProps) {
+export function Badge({ disableStyles = false }: ConnectButtonProps) {
     const [user, setUser] = useState<HappyUser | undefined>(undefined)
 
     const { connecting, connect, open } = useConnection()

--- a/packages/core/lib/badge/define.tsx
+++ b/packages/core/lib/badge/define.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource preact */
-export type { BadgeProps } from "./badge"
+export type { ConnectButtonProps } from "./badge"
 
 function setStyles(stylesId: string, css: string) {
     const prev = document.head.querySelector(`#${stylesId}`)

--- a/packages/core/lib/index.ts
+++ b/packages/core/lib/index.ts
@@ -48,5 +48,5 @@ export type { HappyPublicClient, HappyWalletClient } from "./viem"
 
 export { happyWagmiConnector, createHappyChainWagmiConfig } from "./wagmi"
 
-export type { BadgeProps } from "./badge/define"
+export type { ConnectButtonProps } from "./badge/define"
 export { getChain } from "./utils/getChain"

--- a/packages/react/lib/components/Badge.tsx
+++ b/packages/react/lib/components/Badge.tsx
@@ -1,10 +1,10 @@
-import type { BadgeProps } from "@happy.tech/core"
-export type { BadgeProps }
+import type { ConnectButtonProps } from "@happy.tech/core"
+export type { ConnectButtonProps }
 declare module "react" {
     // biome-ignore lint/style/noNamespace:
     namespace JSX {
         interface IntrinsicElements {
-            "happychain-connect-button": BadgeProps
+            "happychain-connect-button": ConnectButtonProps
         }
     }
 }
@@ -13,6 +13,6 @@ declare module "react" {
  * Simple wrapper to create a react component from the native web component
  */
 
-export function ConnectButton({ disableStyles }: BadgeProps) {
+export function ConnectButton({ disableStyles }: ConnectButtonProps) {
     return <happychain-connect-button disable-styles={disableStyles} />
 }

--- a/packages/react/lib/index.ts
+++ b/packages/react/lib/index.ts
@@ -3,5 +3,5 @@ export {
     useHappyWallet,
     type HappyWalletProviderProps,
 } from "./components/HappyWalletProvider"
-export { ConnectButton, type BadgeProps } from "./components/Badge"
+export { ConnectButton, type ConnectButtonProps } from "./components/Badge"
 export type { HappyProvider, LoadHappyWalletOptions, HappyUser } from "@happy.tech/core"


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-626/rename-badgeprops-%E2%86%92-connectbuttonprops

### Description

Renamed `BadgeProps` to `ConnectButtonProps` across both `@happy.tech/react` and `@happy.tech/core` packages to better reflect the component's purpose and maintain consistent naming conventions.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>