### PR TITLE
Remove redundant URI encoding for app URLs in permissions routes

### DIFF
--- a/apps/iframe/src/components/interface/home/AppStatus.tsx
+++ b/apps/iframe/src/components/interface/home/AppStatus.tsx
@@ -12,7 +12,7 @@ export const AppStatus = () => {
         <div className="z-10 mt-auto py-2 bg-base-200 sticky bottom-0 focus-within:bg-neutral/5 rounded-md flex w-full items-center justify-center text-xs font-bold">
             <Link
                 to="/embed/permissions/$appURL"
-                params={{ appURL: encodeURI(getAppURL()) }}
+                params={{ appURL: getAppURL() }}
                 className="flex items-center gap-2"
                 title={`View ${new URL(getAppURL()).host} permissions`}
                 aria-label={`View ${new URL(getAppURL()).host} permissions`}

--- a/apps/iframe/src/components/interface/permissions/ListAppsWithPermissions.tsx
+++ b/apps/iframe/src/components/interface/permissions/ListAppsWithPermissions.tsx
@@ -35,7 +35,7 @@ const ListItem = ({ appURL }: ListItemProps) => {
             <Link
                 className="absolute size-full block inset-0 z-10 opacity-0"
                 to="/embed/permissions/$appURL"
-                params={{ appURL: encodeURI(appURL) }}
+                params={{ appURL }}
             >
                 Open {appURL} detailed permissions list
             </Link>

--- a/apps/iframe/src/routes/__root.tsx
+++ b/apps/iframe/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { Outlet, type RouterEvents, createRootRoute, useRouter } from "@tanstack/react-router"
+import { Outlet, createRootRoute, useRouter } from "@tanstack/react-router"
 import { revokedSessionKeys } from "#src/state/interfaceState"
 import type { AppURL } from "#src/utils/appURL"
 import "#src/connections/initialize"
@@ -17,13 +17,13 @@ function RootComponent() {
         // This fires after a route transition completes.
         // cf. https://tanstack.com/router/latest/docs/framework/react/api/router/RouterType#subscribe-method
         // cf. https://tanstack.com/router/latest/docs/framework/react/api/router/RouterEventsType
-        return router.subscribe("onResolved", async (event: RouterEvents["onResolved"]) => {
+        return router.subscribe("onResolved", async (event) => {
             const isFromAppPermissionsPage = event.fromLocation?.pathname.match(/^\/embed\/permissions\/(.+)$/)
 
             // Checks if the navigation originated from `/embed/permissions/:appURL` and, if
             // so, revokes the permissions of the session keys associated with the app.
             if (isFromAppPermissionsPage) {
-                const app = decodeURI(isFromAppPermissionsPage[1]) as AppURL
+                const app = decodeURIComponent(isFromAppPermissionsPage[1]) as AppURL
                 await revokeSessionKeys(app, [...revokedSessionKeys.values()])
             }
         })

--- a/apps/iframe/src/routes/embed/permissions.$appURL.lazy.tsx
+++ b/apps/iframe/src/routes/embed/permissions.$appURL.lazy.tsx
@@ -12,7 +12,7 @@ export const Route = createLazyFileRoute("/embed/permissions/$appURL")({
 function DappPermissions() {
     const appURL = useParams({
         from: "/embed/permissions/$appURL",
-        select: (params) => decodeURI(params.appURL),
+        select: (params) => params.appURL,
     }) as AppURL
 
     // Very purposefully not reactive: when revoking a permission, it will show as toggled off instead of vanishing,


### PR DESCRIPTION
### Description

This PR removes unnecessary URI encoding/decoding operations in the iframe app's routing system. The changes include:

- Removed `encodeURI` calls when passing app URLs as route parameters in `AppStatus.tsx` and `ListAppsWithPermissions.tsx`
- Changed `decodeURI` to `decodeURIComponent` in the root route handler to properly handle special characters in URLs
- Removed explicit type annotation for the router event in the subscription handler
- Simplified parameter handling in the permissions route by removing redundant decoding

These changes streamline URL handling in the routing system while ensuring proper URL encoding/decoding where needed.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>