### PR TITLE
Replace chalk with internal colors utility in build scripts

### DIFF
--- a/support/happybuild/lib/buidl/checkExportedTypes.ts
+++ b/support/happybuild/lib/buidl/checkExportedTypes.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun"
-import chalk from "chalk"
 import type { Config } from "../config/types"
+import { colors } from "../utils/colors"
 import { pkg, pkgExportNames } from "../utils/globals"
 import { spinner } from "../utils/spinner"
 import { withOutputsInExportDirs } from "../utils/symlinks"
@@ -73,9 +73,9 @@ export async function checkExportedTypes(configs: Config[]) {
     const table: Record<string, string>[] = []
     for (const row of rows) {
         const tableRow: Record<string, string> = {}
-        tableRow[chalk.blue("target")] = row.shift()!
+        tableRow[colors.blue("target")] = row.shift()!
         for (const [i, result] of row.entries()) {
-            tableRow[chalk.green(headers[i])] = result
+            tableRow[colors.green(headers[i])] = result
         }
         table.push(tableRow)
     }

--- a/support/happybuild/lib/buidl/rollupTypes.ts
+++ b/support/happybuild/lib/buidl/rollupTypes.ts
@@ -2,8 +2,8 @@ import { existsSync } from "node:fs"
 import { basename, join } from "node:path"
 import { Extractor, ExtractorConfig, type ExtractorResult } from "@microsoft/api-extractor"
 import { $ } from "bun"
-import chalk from "chalk"
 import type { Config } from "../config/types"
+import { colors } from "../utils/colors"
 import { base } from "../utils/globals"
 import { spinner } from "../utils/spinner"
 import { tscBuild } from "./typescript"
@@ -35,10 +35,10 @@ export async function rollupTypes(config: Config) {
     const typesfilename = basename(extractorConfig.mainEntryPointFilePath).replace(/(.es)?\.d\.ts/, "")
     if (entryfilename !== typesfilename) {
         console.warn(
-            `\n[${chalk.yellow(config.fullName)}] API-Extractor is configured to process '${chalk.red(`${typesfilename}.ts`)}', expecting '${chalk.green(`${entryfilename}.ts`)}'.`,
+            `\n[${colors.yellow(config.fullName)}] API-Extractor is configured to process '${colors.red(`${typesfilename}.ts`)}', expecting '${colors.green(`${entryfilename}.ts`)}'.`,
         )
         console.warn(
-            `[${chalk.yellow(config.fullName)}] Verify the api-extractor "mainEntryPointFilePath" and ensure its pointing to the correct path for this entrypoint.`,
+            `[${colors.yellow(config.fullName)}] Verify the api-extractor "mainEntryPointFilePath" and ensure its pointing to the correct path for this entrypoint.`,
         )
         throw new Error("API-Extractor mainEntryPointFilePath mismatch")
     }
@@ -56,7 +56,7 @@ function invokeExtractor(extractorConfig: ExtractorConfig): ExtractorResult {
     const ogLog = console.log.bind(console)
     const ogWarn = console.warn.bind(console)
     console.log = () => {}
-    console.warn = (...msg) => ogWarn(chalk.blue("[@microsoft/api-extractor]"), ...msg)
+    console.warn = (...msg) => ogWarn(colors.blue("[@microsoft/api-extractor]"), ...msg)
 
     const result = Extractor.invoke(extractorConfig, {
         localBuild: true,

--- a/support/happybuild/lib/buidl/typing.ts
+++ b/support/happybuild/lib/buidl/typing.ts
@@ -1,8 +1,8 @@
 import { join } from "node:path"
 import { $ } from "bun"
-import chalk from "chalk"
 import type { Context } from "../build"
 import type { Config } from "../config/types"
+import { colors } from "../utils/colors"
 import { base } from "../utils/globals"
 import { spinner } from "../utils/spinner"
 import { rollupTypes } from "./rollupTypes"
@@ -33,7 +33,7 @@ export async function handleTypes(config: Config, ctx: Context) {
             await rollupTypes(config)
         } catch (e) {
             console.error(e)
-            console.warn(`[${chalk.yellow(config.fullName)}] ${chalk.red("Failed to rollup types. Creating Stub.")}`)
+            console.warn(`[${colors.yellow(config.fullName)}] ${colors.red("Failed to rollup types. Creating Stub.")}`)
             throw e
         }
         const t1 = performance.now()


### PR DESCRIPTION
### Description

Replaced the direct usage of `chalk` with a custom `colors` utility across the build system. This change centralizes color handling in the `colors.ts` utility file, making it easier to maintain and customize color schemes throughout the codebase.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>