### PR TITLE
Use getCurrentUser() instead of user.address in token minting function

### DIFF
--- a/demos/react/src/demo-components/WalletFunctionalityDemo.tsx
+++ b/demos/react/src/demo-components/WalletFunctionalityDemo.tsx
@@ -1,4 +1,4 @@
-import { loadAbi, showSendScreen } from "@happy.tech/core"
+import { connect, getCurrentUser, loadAbi, showSendScreen } from "@happy.tech/core"
 import { useHappyWallet } from "@happy.tech/react"
 import { toast } from "sonner"
 import { walletClient } from "../clients"
@@ -30,12 +30,17 @@ const WalletFunctionalityDemo = () => {
     /** mints 1 MTA token to the connected account */
     async function mintTokens() {
         try {
-            if (!user?.address) return
+            // For many calls we can rely on the wallet to handle automatically prompting the user to
+            // connect if required, however this call requires the users address to be known ahead
+            // of time so it can be provided to 'args'. In this case we must manually call connect()
+            // to ensure there is a user connected to the wallet, and in args, we may call
+            // `getCurrentUser()` to get the address without waiting for react to re-render.
+            if (!user?.address) await connect()
             const writeCallResult = await walletClient.writeContract({
                 address: deployment.MockTokenA,
                 abi: abis.MockTokenA,
                 functionName: "mint",
-                args: [user.address, 1000000000000000000n],
+                args: [getCurrentUser()!.address, 1000000000000000000n],
             })
             if (writeCallResult) {
                 console.log("[mintTokens] success:", writeCallResult)


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

Improved wallet connection flow in the `mintTokens` function by:

1. Adding explicit connection handling when user address is not available
2. Using `getCurrentUser()` instead of relying on the potentially stale `user.address` value
3. Added explanatory comment about when explicit connection handling is required

This change ensures that the token minting functionality works correctly even when the user's wallet is not yet connected, by proactively connecting before attempting to mint tokens.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>