### PR TITLE
chore(submitter): change prometheus port in submitter

### DIFF
--- a/.github/workflows/deploy-staging-submitter.yml
+++ b/.github/workflows/deploy-staging-submitter.yml
@@ -62,7 +62,7 @@ jobs:
             RPC_URLS=ws://localhost:8546,http://localhost:8545
             USE_STAGING_CONTRACTS=true
             TRACES_ENDPOINT=http://localhost:4318/v1/traces
-            PROMETHEUS_PORT=9090
+            PROMETHEUS_PORT=9091
             EOF
               cd /home/staging_submitter/build
               bun migrate.es.js

--- a/.github/workflows/deploy-submitter.yml
+++ b/.github/workflows/deploy-submitter.yml
@@ -61,7 +61,7 @@ jobs:
             NODE_ENV=production
             RPC_URLS=ws://localhost:8546,http://localhost:8545
             TRACES_ENDPOINT=http://localhost:4318/v1/traces
-            PROMETHEUS_PORT=9091
+            PROMETHEUS_PORT=9092
             EOF
               cd /home/submitter/build
               bun migrate.es.js


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

< DESCRIPTION GOES HERE >

- Include all relevant context (but no need to repeat the issue's content).
- Draw attention to new, noteworthy & unintuitive elements.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>
