### PR TITLE
feat: change emission of BoopSubmitted

### DIFF
--- a/contracts/src/boop/core/EntryPoint.sol
+++ b/contracts/src/boop/core/EntryPoint.sol
@@ -45,9 +45,7 @@ contract EntryPoint is Staking, ReentrancyGuardTransient {
      * having a single argument with the struct — this enables better display on some block explorers
      * like Blockscout.
      *
-     * @dev It is crucial that the fields here be identical to those in the {interfaces/Types.Boop} struct. Because
-     * Solidity refuses to emit events with more than 15 arguments, we simply use the abi-encoding of the struct to emit
-     * this event.
+     * @dev It is crucial that the fields here be identical to those in the {interfaces/Types.Boop} struct.
      */
     event BoopSubmitted(
         address account,
@@ -196,8 +194,23 @@ contract EntryPoint is Staking, ReentrancyGuardTransient {
 
         // ==========================================================================================
         // 5. Emit Boop Submitted
-
-        _emitBoopSubmitted(boop);
+        emit BoopSubmitted(
+            boop.account,
+            boop.dest,
+            boop.payer,
+            boop.value,
+            boop.nonceTrack,
+            boop.nonceValue,
+            boop.maxFeePerGas,
+            boop.submitterFee,
+            boop.gasLimit,
+            boop.validateGasLimit,
+            boop.validatePaymentGasLimit,
+            boop.executeGasLimit,
+            boop.callData,
+            boop.validatorData,
+            boop.extraData
+        );
 
         // ==========================================================================================
         // 6. Collect payment
@@ -333,23 +346,6 @@ contract EntryPoint is Staking, ReentrancyGuardTransient {
         if (status > CallStatus.EXECUTE_REVERTED) {
             // The returned status is incorrect, treat this like a revert.
             status = CallStatus.EXECUTE_REVERTED;
-        }
-    }
-
-    /**
-     * Emits an {interfaces/EventsAndErrors.BoopSubmitted} event containing the struct. This
-     * needs assembly, as Solidity can handle max 15 arguments before running out of stack space
-     * (irrespective of context).
-     */
-    function _emitBoopSubmitted(Boop memory boop) internal {
-        // Structs are encoded as tuples, just like events, and the signature of the event matches
-        // that of the struct. The only difference is that the struct is prefixed with an offset.
-        bytes memory args = abi.encode(boop);
-        bytes32 topic = BoopSubmitted.selector;
-        assembly {
-            let data := add(args, 64) // skip bytes length and offset to struct
-            let size := sub(mload(args), 32) // length of the bytestring minus size of offset
-            log1(data, size, topic)
         }
     }
 }


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-629/rework-boop-event


Change confirmed to work - see https://github.com/HappyChainDevs/happychain/pull/909

### Description

< DESCRIPTION GOES HERE >

- Include all relevant context (but no need to repeat the issue's content).
- Draw attention to new, noteworthy & unintuitive elements.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>
