### PR TITLE
Update solc version to 0.8.30 and EVM version to Prague

### DIFF
--- a/apps/submitter/lib/env/schemas/gas.ts
+++ b/apps/submitter/lib/env/schemas/gas.ts
@@ -109,7 +109,7 @@ export const gasSchema = z.object({
      * Gas limit for the account creation call, avoiding a chain roundtrip for simulation.
      * Defaults to 300k.
      *
-     * Our last measurement (07 Jun 2025) is 246493 gas used.
+     * Our last measurement (14 Jun 2025, Prague hard fork) is 246_493 gas used.
      */
     ACCOUNT_CREATION_GAS_LIMIT: z.coerce.bigint().positive().default(300_000n),
 })

--- a/apps/submitter/lib/handlers/createAccount/createAccount.ts
+++ b/apps/submitter/lib/handlers/createAccount/createAccount.ts
@@ -33,11 +33,11 @@ async function createAccount({ salt, owner }: CreateAccountInput): Promise<Creat
         // TODO must resync nonce if this fails
         logger.trace("Sending account creation tx", predictedAddress)
         const hash = await walletClient.writeContract({
+            account: accountDeployer,
             address: deployment.HappyAccountBeaconProxyFactory,
             abi: abis.HappyAccountBeaconProxyFactory,
             functionName: "createAccount",
             args: [salt, owner],
-            account: accountDeployer,
             gas: env.ACCOUNT_CREATION_GAS_LIMIT,
             // TODO validate that fees are not above the max
             ...getFees(),

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,11 +1,11 @@
-# Full reference
-# https://book.getfoundry.sh/reference/config/
+# Full reference: https://getfoundry.sh/config/reference/README/
+# Defaults: https://getfoundry.sh/config/reference/default-config/
 
 [profile.default]
 # The default profile is always applied, even if a specific profile is specified.
 
-# For Cancun hardfork + enables transient variables support.
-solc_version = "0.8.28"
+# For Prague hardfork + enables transient variables support.
+solc_version = "0.8.30"
 
 optimizer = true
 optimizer_runs = 20000
@@ -13,8 +13,7 @@ via_ir = true
 
 ignored_warnings_from = ["node_modules", "lib", "src/deploy", "src/scripts", "src/test"]
 
-# Forge targets Paris by default.
-evm_version = "cancun"
+evm_version = "prague"
 
 # Needed to write from the deploy scripts.
 fs_permissions = [


### PR DESCRIPTION
### Linked Issues

- closes [HAPPY-630](https://linear.app/happychain/issue/HAPPY-630/bump-foundry-evm-version-to-prague)

### Description

This PR updates the Solidity compiler version from 0.8.28 to 0.8.30 and changes the EVM version from Cancun to Prague in the Foundry configuration. The update also includes regenerated contract addresses for HappyAccountBeacon, HappyAccountBeaconProxyFactory, and HappyAccountImpl in the Anvil deployment files.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>