### PR TITLE
add retry-after header for 503 response from submitter

### DIFF
--- a/.changeset/strong-donuts-cut.md
+++ b/.changeset/strong-donuts-cut.md
@@ -1,5 +1,0 @@
----
-"@happy.tech/submitter": patch
----
-
-Add Retry-After header for 503 response from submitter.

--- a/apps/submitter/lib/server/boopRoute.ts
+++ b/apps/submitter/lib/server/boopRoute.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono"
+import type { ResponseHeader } from "hono/utils/headers"
 import { executeBodyValidation, executeDescription } from "#lib/handlers/execute"
 import { execute } from "#lib/handlers/execute/execute"
 import { executeOutputValidation } from "#lib/handlers/execute/validation"
@@ -47,11 +48,7 @@ export default new Hono()
             const input = c.req.valid("json")
             const output = await submit(input)
             const [body, code, headers] = makeResponse(output)
-            if (headers) {
-                Object.entries(headers).forEach(([key, value]) => {
-                    c.header(key, value)
-                })
-            }
+            for (const k in headers) c.header(k, headers[k as ResponseHeader])
             validateOutput(body, submitOutputValidation, "submit response")
             return c.json(body, code)
         },
@@ -64,11 +61,7 @@ export default new Hono()
             const input = c.req.valid("json")
             const output = await execute(input)
             const [body, code, headers] = makeResponse(output)
-            if (headers) {
-                Object.entries(headers).forEach(([key, value]) => {
-                    c.header(key, value)
-                })
-            }
+            for (const k in headers) c.header(k, headers[k as ResponseHeader])
             validateOutput(body, executeOutputValidation, "execute response")
             return c.json(body, code)
         },


### PR DESCRIPTION
### Linked Issues
closes https://linear.app/happychain/issue/HAPPY-555/set-retry-after-http-header

### Description

Add Retry-After header for 503 response from submitter. When the submitter returns an OverCapacity error (status code 503), it now includes a Retry-After header with a value of 10 seconds to inform clients when they should retry their request.

cf: https://github.com/HappyChainDevs/happychain/blob/4ce2f4966c6b4d8c9d76830fe4936aa0249736d3/apps/submitter/lib/server/makeResponse.ts#L76

<details closed>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [x] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [x] B2. This PR is not so big that it should be split & addresses only one concern.
- [x] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [x] C1. Builds and passes tests.
- [x] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [x] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [x] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [x] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [x] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [x] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [x] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>