### PR TITLE
Add chain switch error in production

### DIFF
--- a/apps/iframe/src/requests/handlers/approved.ts
+++ b/apps/iframe/src/requests/handlers/approved.ts
@@ -46,9 +46,7 @@ export async function dispatchApprovedRequest(request: PopupMsgs[Msgs.PopupAppro
             return grantPermissions(app, request.payload.params[0])
 
         case "wallet_addEthereumChain": {
-            if (import.meta.env.PROD) {
-                throw new EIP1474InvalidInput("Feature not available in production")
-            }
+            if (import.meta.env.PROD) throw new EIP1474InvalidInput("Feature not available in production.")
             const params = Array.isArray(request.payload.params) && request.payload.params[0]
             const isValid = isAddChainParams(params)
             if (!isValid) throw new EIP1474InvalidInput("Invalid wallet_addEthereumChain request body")
@@ -60,9 +58,7 @@ export async function dispatchApprovedRequest(request: PopupMsgs[Msgs.PopupAppro
         }
 
         case "wallet_switchEthereumChain": {
-            if (import.meta.env.PROD) {
-                throw new EIP1474InvalidInput("Feature not available in production")
-            }
+            if (import.meta.env.PROD) throw new EIP1474InvalidInput("Feature not available in production.")
             const chains = getChains()
             const chainId = request.payload.params[0].chainId
             if (!(chainId in chains))

--- a/apps/iframe/src/requests/handlers/permissionless.ts
+++ b/apps/iframe/src/requests/handlers/permissionless.ts
@@ -1,7 +1,8 @@
 import { HappyMethodNames } from "@happy.tech/common"
 import {
-    EIP1193UnsupportedMethodError,
+    EIP1193SwitchChainError,
     EIP1193UserRejectedRequestError,
+    EIP1474InvalidInput,
     type Msgs,
     type ProviderMsgsFromApp,
 } from "@happy.tech/wallet-common"
@@ -92,16 +93,12 @@ export async function dispatchedPermissionlessRequest(request: ProviderMsgsFromA
             return []
 
         case "wallet_addEthereumChain":
-            if (import.meta.env.PROD) {
-                throw new EIP1193UnsupportedMethodError("feature not available in production")
-            }
+            if (import.meta.env.PROD) throw new EIP1474InvalidInput("Feature not available in production.")
             // If this is permissionless, the chain already exists, so we simply succeed.
             return null
 
         case "wallet_switchEthereumChain":
-            if (import.meta.env.PROD) {
-                throw new EIP1193UnsupportedMethodError("feature not available in production")
-            }
+            if (import.meta.env.PROD) throw new EIP1193SwitchChainError("Feature not available in production.")
             // If this is permissionless, we're already on the right chain so we simply succeed.
             return null
 

--- a/support/common/lib/utils/promises.ts
+++ b/support/common/lib/utils/promises.ts
@@ -63,7 +63,7 @@ export async function delayed<T>(timeout: number, value: Lazy<MaybePromise<T>>):
 export async function waitForCondition(condition: Fn, timeoutMs = 30_000, intervalMs = 50): Promise<void> {
     if (await condition()) return
     const pwr = Promise.withResolvers()
-    const interval = setInterval(async () => (await condition()) && pwr.resolve(), intervalMs)
+    const interval = setInterval(async () => (await condition()) && pwr.resolve(undefined), intervalMs)
     try {
         await Promise.race([pwr.promise, sleep(timeoutMs)])
     } finally {

--- a/support/wallet-common/lib/interfaces/permissions.ts
+++ b/support/wallet-common/lib/interfaces/permissions.ts
@@ -3,6 +3,18 @@ import type { EIP1193Parameters } from "viem"
 
 // https://eips.ethereum.org/EIPS/eip-1474
 
+// Disabled - These are 'disabled' methods. they are added here so that the user is not presented
+// with a confirmation screen, and 'permissionless' requests will directly throw an error if they
+// are called. To enable the popup for these methods, remove them here (they should already be present
+// in the unsafeList)
+const disabledInProdList = import.meta.env.PROD
+    ? [
+          "wallet_addEthereumChain", // https://eips.ethereum.org/EIPS/eip-3085
+          "wallet_switchEthereumChain", // https://eips.ethereum.org/EIPS/eip-3326
+          "wallet_updateEthereumChain", // https://eips.ethereum.org/EIPS/eip-2015
+      ]
+    : []
+
 /**
  * This is the list of methods that will never require a user confirmation.
  * Most such as eth_chainId are fully public RPC calls.
@@ -10,6 +22,8 @@ import type { EIP1193Parameters } from "viem"
  * Some such as wallet_revokePermissions don't make sense if a user isn't connected, but are still safe to call.
  */
 const safeList = new Set([
+    ...disabledInProdList,
+
     // happychain methods
     HappyMethodNames.USER, // => returns the current connected user if permissions are granted and user is connected
 


### PR DESCRIPTION
### Description

This PR improves error handling for Ethereum chain management methods in production environments. It standardizes error messages and types for `wallet_addEthereumChain` and `wallet_switchEthereumChain` methods, ensuring consistent behavior across the application.

Key changes:
- Added these methods to a `disabledInProdList` to prevent confirmation screens in production
- Standardized error messages with proper periods and consistent capitalization
- Fixed a potential issue in `waitForCondition` by explicitly passing `undefined` to the resolver
- Simplified conditional blocks by removing unnecessary braces for single-line conditions
- Used more specific error types (`EIP1474InvalidInput` and `EIP1193SwitchChainError`) for better error handling

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>