### PR TITLE
feat: fuzz createAccount to observe potential failure

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -102,6 +102,10 @@ test-gas: ## Runs test and generate a gas report
 	forge test --gas-report
 .PHONY: test-gas
 
+test-fuzz:
+	forge test --match-test test_fuzz_NoLeading0xEF --fuzz-runs 100000
+.PHONY: test-fuzz
+
 ####################################################################################################
 # Boop Unit Tests
 

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -24,6 +24,9 @@ fs_permissions = [
 # Formatter Options
 line_width = 120
 
+# Fuzzing settings
+fail_on_revert = true
+
 [profile.upgrade]
 # Flags needed for OpenZeppelin upgrade validation.
 ffi = true

--- a/contracts/src/test/boop/happychain/HappyAccountFactory.t.sol
+++ b/contracts/src/test/boop/happychain/HappyAccountFactory.t.sol
@@ -86,6 +86,22 @@ contract HappyAccountFactoryTest is Test {
         assertEq(_getOwner(firstDeployed), _getOwner(secondDeployed), "Both accounts should be owned by OWNER");
     }
 
+    // solhint-disable-next-line func-name-mixedcase
+    function test_fuzz_NoLeading0xEF(address owner, bytes32 salt) public {
+        vm.assume(owner != address(0));
+        // skip if already deployed
+        address predicted = factory.getAddress(salt, owner);
+        vm.assume(!_hasCode(predicted));
+
+        address deployed = factory.createAccount(salt, owner);
+
+        // invariants
+        bytes memory code = deployed.code;
+        assertGt(code.length, 0, "deployed contract must have code");
+        // EIP-3541 guard: first byte must not be 0xEF
+        assertTrue(uint8(code[0]) != 0xef, "byte-code starts with 0xEF");
+    }
+
     // ====================================================================================================
     // HELPER FUNCTIONS
 


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

Added a new fuzzing test for the HappyAccountFactory to ensure deployed contracts never start with byte 0xEF (as per EIP-3541). The test verifies this constraint across 100,000 fuzz runs with different owner addresses and salt values.

The PR includes:
- A new `test-fuzz` make target to run the fuzzing test with 100,000 iterations
- Configuration in foundry.toml to fail on revert during fuzzing
- Implementation of the `test_fuzz_NoLeading0xEF` test function that validates deployed contracts

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>