### PR TITLE
Improve drag handling on non-chrome environments

### DIFF
--- a/.changeset/public-tigers-appear.md
+++ b/.changeset/public-tigers-appear.md
@@ -1,0 +1,5 @@
+---
+"@happy.tech/common": patch
+---
+
+Update default throttle timer from 120FPS to 60FPS

--- a/.changeset/smooth-news-float.md
+++ b/.changeset/smooth-news-float.md
@@ -1,0 +1,5 @@
+---
+"@happy.tech/core": patch
+---
+
+Fix drag handler getting stuck dragging on non-chrome browsers

--- a/packages/core/lib/wallet/HappyWallet.tsx
+++ b/packages/core/lib/wallet/HappyWallet.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource preact */
+import { useRef } from "preact/hooks"
 import { WalletFrame } from "./WalletFrame"
 import { IsOpenContext, useSetupIsOpenContext } from "./context/IsOpenContext"
 import { useWalletDragger } from "./hooks/useWalletDragger"
@@ -18,7 +19,8 @@ export interface HappyWalletProps {
  */
 export const HappyWallet = ({ windowId, chainId }: HappyWalletProps) => {
     const { isOpen, setIsOpen } = useSetupIsOpenContext()
-    const { handleOffset, walletOffset, dragging, dragProps } = useWalletDragger()
+    const walletRef = useRef<HTMLDivElement>(null)
+    const { handleOffset, walletOffset, dragging, dragProps } = useWalletDragger({ containerRef: walletRef })
 
     if (!chainId || !windowId) {
         throw new Error("Misconfigured HappyWallet. ")
@@ -28,6 +30,7 @@ export const HappyWallet = ({ windowId, chainId }: HappyWalletProps) => {
         <>
             <style>{cssStyles}</style>
             <div
+                ref={walletRef}
                 data-open-state={isOpen}
                 data-drag-state={dragging}
                 style={{ "--happy-translate-y": `${handleOffset}px` }}

--- a/packages/core/lib/wallet/hooks/useWalletDragger.ts
+++ b/packages/core/lib/wallet/hooks/useWalletDragger.ts
@@ -1,16 +1,42 @@
 import { throttle } from "@happy.tech/common"
-import { useEffect, useRef, useState } from "preact/hooks"
-import { isChrome, makeBlankImage } from "../utils"
+import type { RefObject } from "preact"
+import { useCallback, useEffect, useRef, useState } from "preact/hooks"
+import { browserFeatures, isChrome, makeBlankImage } from "../utils"
 import { useBreakpoint } from "./useBreakpoint"
 
+/**
+ * Default height of the draggable wallet handle in pixels.
+ * Used as a fallback before we can measure the actual height.
+ */
+const DEFAULT_HEIGHT = 56
+
+/**
+ * A blank image used to suppress the browser's default drag "ghost" image.
+ * This creates a cleaner drag UX, where native drag is supported.
+ */
 const blank = makeBlankImage()
 
+/**
+ * Rounds a fractional offset to 4 decimal places.
+ * Prevents floating point drift and keeps percentages consistent in storage/UI.
+ */
 const roundedOffset = (offset: number) => Math.round(offset * 10000) / 10000
 
-// we can't get the max bound since we may not know the element height here
+/**
+ * Retrieves the cached vertical offset of the wallet from localStorage,
+ * multiplied by the current usable height to get an absolute pixel value.
+ *
+ * `usableWindowHeight` is passed in rather than computed here so the caller can
+ * decide how to account for dynamic UI elements (like the handle height).
+ */
 const getCachedPosition = (usableWindowHeight: number) => {
     return Math.max(Number(localStorage.getItem("happychain:handlePosition.y") || 0), 0) * usableWindowHeight
 }
+
+/**
+ * Saves the handle's vertical position as a **percentage** (between 0 and 1) of
+ * the usable window height. This allows consistent positioning across resizes.
+ */
 const cachePosition = (position: number, usableWindowHeight: number) => {
     localStorage.setItem(
         "happychain:handlePosition.y",
@@ -18,69 +44,112 @@ const cachePosition = (position: number, usableWindowHeight: number) => {
     )
 }
 
-function getParentBoundingRec(e: Event) {
-    if (e.target && "closest" in e.target && e.target.closest && typeof e.target.closest === "function") {
-        return e.target.closest(".wallet-container").getBoundingClientRect?.()
-    }
+/**
+ * Safely retrieves the bounding client rectangle of a given HTMLElement reference.
+ */
+function getBoundingRectFromRef(ref: HTMLElement | null) {
+    return ref?.getBoundingClientRect?.()
 }
 
+/**
+ * Ensures the drag offset stays within bounds:
+ * - not less than 0 (top of screen)
+ * - not greater than maxHeight (bottom limit)
+ */
 function getBoundedOffset(boxTop: number, maxHeight: number) {
     return Math.min(Math.max(boxTop, 0), maxHeight)
 }
 
-function useNativeDrag({ enabled }: { enabled: boolean }) {
-    // we will hardcode 48 on page load as the default height, but on click we re-evaluate
-    const [boundingRec, setBoundingRec] = useState({ height: 56 })
+function useWalletDragSharedState(containerRef: RefObject<HTMLElement | null>) {
+    // we will hardcode 56 on page load as the default height, but on click we re-evaluate
+    const [boundingRect, setBoundingRect] = useState({ height: DEFAULT_HEIGHT })
     // absolute position of wallet onscreen (y axis in pixels)
-    const [handleOffset, setHandleOffset] = useState(getCachedPosition(window.innerHeight - boundingRec.height))
+    const [handleOffset, setHandleOffset] = useState(() =>
+        typeof window === "undefined" ? 0 - DEFAULT_HEIGHT : getCachedPosition(window.innerHeight - DEFAULT_HEIGHT),
+    )
 
-    // offset in percentage (so resizes, will retain same location onscreen)
-    // const [walletOffset, setWalletOffset] = useState(roundedOffset(handleOffset / window.innerHeight))
     // relative offset to move orb since clicks won't be perfectly centered on orb
     const [dragStartOffset, setDragStartOffset] = useState(0)
 
     // is the orb currently dragging
     const [dragging, setDragging] = useState(false)
 
-    // resize handler
-    useEffect(() => {
-        if (!enabled) return
+    const getMaxHeight = useCallback(() => window.innerHeight - boundingRect.height, [boundingRect.height])
 
+    const maxHeight = getMaxHeight()
+    const pxOffset = boundingRect.height * (handleOffset / maxHeight)
+
+    // offset in percentage (so resizes, will retain same location onscreen)
+    const walletOffset = roundedOffset(handleOffset / maxHeight) * -100
+
+    // Update offset on resize
+    useEffect(() => {
         const handleResize = () => {
-            const nextOffset = getBoundedOffset(
-                getCachedPosition(window.innerHeight - boundingRec.height),
-                window.innerHeight - boundingRec.height,
-            )
+            const maxHeight = getMaxHeight()
+            const nextOffset = getBoundedOffset(getCachedPosition(maxHeight), maxHeight)
             setHandleOffset(nextOffset)
         }
 
         window.addEventListener("resize", handleResize)
         return () => window.removeEventListener("resize", handleResize)
-    })
+    }, [getMaxHeight])
+
+    return {
+        // firefox and others don't properly support native drag-and-drop
+        enableNativeDrag: browserFeatures.dragAndDrop && isChrome,
+        containerRef,
+        boundingRect,
+        setBoundingRect,
+        dragging,
+        setDragging,
+        handleOffset,
+        setHandleOffset,
+        dragStartOffset,
+        setDragStartOffset,
+        getMaxHeight,
+
+        // Computed distance that expanded wallet should open
+        // 0% means open down (top of screen), -100% means open up (bottom of screen), -50% means open from middle
+        walletOffset: `calc(${walletOffset}% + ${pxOffset}px)`,
+    }
+}
+
+function useNativeDrag(shared: ReturnType<typeof useWalletDragSharedState>) {
+    const {
+        dragging,
+        setDragging,
+        dragStartOffset,
+        handleOffset,
+        boundingRect,
+        setBoundingRect,
+        setDragStartOffset,
+        setHandleOffset,
+        containerRef,
+    } = shared
 
     function onDragStart(e: DragEvent) {
         if (!e.dataTransfer) return
 
         setDragging(true)
-        const rec = getParentBoundingRec(e)
-        if (rec) {
-            setBoundingRec(rec)
-        }
+
+        const rec = getBoundingRectFromRef(containerRef.current)
+        if (rec) setBoundingRect(rec)
         setDragStartOffset(e.clientY - handleOffset)
 
         // Disables ghosting. cf. makeBlankImage docstring
+        // note: works on chrome, broken on safari in some cases (safari will use useCustomDrag)
         e.dataTransfer.setDragImage(blank, 0, 0)
     }
 
     function onDragEnd(e: DragEvent) {
         setDragging(false)
 
-        const nextOffset = getBoundedOffset(e.clientY - dragStartOffset, window.innerHeight - boundingRec.height)
+        const nextOffset = getBoundedOffset(e.clientY - dragStartOffset, window.innerHeight - boundingRect.height)
         setHandleOffset(nextOffset)
         // We persist the percentage, so that if window opens in a different resolution, the grabber
         // will still be in the same 'location'
 
-        cachePosition(nextOffset, window.innerHeight - boundingRec.height)
+        cachePosition(nextOffset, window.innerHeight - boundingRect.height)
     }
 
     const onDrag = throttle((e: DragEvent) => {
@@ -91,20 +160,11 @@ function useNativeDrag({ enabled }: { enabled: boolean }) {
         // is not noticeable by the user
         if (!e.clientY) return
 
-        const nextOffset = getBoundedOffset(e.clientY - dragStartOffset, window.innerHeight - boundingRec.height)
+        const nextOffset = getBoundedOffset(e.clientY - dragStartOffset, window.innerHeight - boundingRect.height)
         setHandleOffset(nextOffset)
     })
 
-    const pxOffset = boundingRec.height * (handleOffset / (window.innerHeight - boundingRec.height))
-    const walletOffset = roundedOffset(handleOffset / (window.innerHeight - boundingRec.height)) * -100
-
     return {
-        // Y offset of orb
-        handleOffset,
-
-        // Computed distance that expanded wallet should open
-        // 0% means open down (top of screen), -100% means open up (bottom of screen), -50% means open from middle
-        walletOffset: `calc(${walletOffset}% + ${pxOffset}px)`,
         dragging,
         dragProps: {
             // browsers that properly support dragging
@@ -116,135 +176,131 @@ function useNativeDrag({ enabled }: { enabled: boolean }) {
     }
 }
 
-function useCustomDrag({ enabled }: { enabled: boolean }) {
-    // we will hardcode 48 on page load as the default height, but on click we re-evaluate
-    const [boundingRec, setBoundingRec] = useState({ height: 56 })
-    // absolute position of wallet onscreen (y axis in pixels)
-    const [handleOffset, setHandleOffset] = useState(getCachedPosition(window.innerHeight - boundingRec.height))
+function useCustomDrag(shared: ReturnType<typeof useWalletDragSharedState>) {
+    const {
+        dragging,
+        setDragging,
+        dragStartOffset,
+        handleOffset,
+        setBoundingRect,
+        setDragStartOffset,
+        setHandleOffset,
+        getMaxHeight,
+        enableNativeDrag,
+        containerRef,
+    } = shared
 
-    // relative offset to move orb since clicks won't be perfectly centered on orb
-    const [dragStartOffset, setDragStartOffset] = useState(0)
-    const [dragging, setDragging] = useState(false)
+    // only enabled if nativeDrag is not supported
+    const enabled = !enableNativeDrag
+
     // Firefox: need to disable userSelect manually during drag to avoid highlighting everything
-    const [initialUserSelect] = useState(document.body.style.userSelect)
+    const initialUserSelect = useRef(typeof document !== "undefined" ? document.body.style.userSelect : "")
 
     // FireFox: differentiate between click and drag on devices where html5 draggable doesn't work properly
     const [hasMoved, setHasMoved] = useState(false)
 
-    useEffect(() => {
-        if (!enabled) return
-
-        const handleResize = () => {
-            const nextOffset = getBoundedOffset(
-                getCachedPosition(window.innerHeight - boundingRec.height),
-                window.innerHeight - boundingRec.height,
-            )
-            setHandleOffset(nextOffset)
-        }
-
-        window.addEventListener("resize", handleResize)
-        return () => window.removeEventListener("resize", handleResize)
-    })
-
-    useEffect(() => {
-        if (!enabled) return
-
-        const onDragEnd = (e: MouseEvent) => {
-            e.preventDefault()
-            e.stopPropagation()
-            document.body.style.userSelect = initialUserSelect
-            // we must wait till next tick before updating this so that the click event to open
-            // the wallet still believes us to be dragging, and therefore won't open on dragEnd
-            setTimeout(() => setDragging(false), 0)
-            // We persist the percentage, so that if window opens in a different resolution, the grabber
-            // will still be in the same 'location'
-        }
-        window.addEventListener("mouseup", onDragEnd)
-        return () => {
-            window.removeEventListener("mouseup", onDragEnd)
-        }
-    }, [initialUserSelect, enabled])
-
     const unsubscribe = useRef<null | (() => void)>(null)
 
+    // Mouse up listener (end drag)
     useEffect(() => {
-        if (!enabled) return
+        if (!enabled || !dragging) return
 
-        if (!dragging) {
-            // if dragging has stopped, but unsubscribe hasn't been called,
-            // we must call manually here, as we can't rely on useEffect cleanup
+        const onDragEnd = (e: MouseEvent | FocusEvent) => {
+            e.preventDefault()
+            e.stopPropagation()
+            document.body.style.userSelect = initialUserSelect.current
+            // setTimeout to defer the state change, so that the drag event can complete without
+            // a click event triggering the wallet to open
+            setTimeout(() => setDragging(false), 0)
+        }
+
+        window.addEventListener("mouseup", onDragEnd)
+        window.addEventListener("blur", onDragEnd)
+        window.addEventListener("contextmenu", onDragEnd)
+        return () => {
+            window.removeEventListener("mouseup", onDragEnd)
+            window.removeEventListener("blur", onDragEnd)
+            window.removeEventListener("contextmenu", onDragEnd)
+        }
+    }, [enabled, dragging, setDragging])
+
+    // Mouse move listener (dragging)
+    useEffect(() => {
+        if (!enabled || !dragging) {
+            // Stop if no longer dragging
             if (unsubscribe.current) {
-                unsubscribe.current?.()
+                unsubscribe.current()
                 unsubscribe.current = null
             }
             return
         }
 
-        const onDragStableCallback = (e: MouseEvent) => {
-            if (!enabled) return
-            if (!dragging) return
+        const onDrag = (e: MouseEvent) => {
             if (!e.clientY) return
-            setHasMoved(true)
+            if (e.buttons === 0) {
+                // No buttons held down — abort drag
+                document.body.style.userSelect = initialUserSelect.current
+                setDragging(false)
+                return
+            }
 
+            setHasMoved(true)
             document.body.style.userSelect = "none"
 
-            const nextOffset = getBoundedOffset(e.clientY - dragStartOffset, window.innerHeight - boundingRec.height)
+            const maxHeight = getMaxHeight()
+            const nextOffset = getBoundedOffset(e.clientY - dragStartOffset, maxHeight)
             setHandleOffset(nextOffset)
-            cachePosition(nextOffset, window.innerHeight - boundingRec.height)
+            cachePosition(nextOffset, maxHeight)
         }
 
-        window.addEventListener("mousemove", onDragStableCallback)
+        window.addEventListener("mousemove", onDrag)
+        unsubscribe.current = () => window.removeEventListener("mousemove", onDrag)
 
-        // Handle unsub manually, don't rely on useEffect re-triggers
-        unsubscribe.current = () => {
-            window.removeEventListener("mousemove", onDragStableCallback)
+        return () => {
+            if (unsubscribe.current) {
+                unsubscribe.current()
+                unsubscribe.current = null
+            }
         }
-    }, [dragging, dragStartOffset, boundingRec.height, enabled])
-
-    const pxOffset = boundingRec.height * (handleOffset / (window.innerHeight - boundingRec.height))
-    const walletOffset = roundedOffset(handleOffset / (window.innerHeight - boundingRec.height)) * -100
+    }, [enabled, dragging, dragStartOffset, getMaxHeight, setHandleOffset, setDragging])
 
     return {
-        handleOffset,
-
-        // Computed distance that expanded wallet should open
-        // 0% means open down (top of screen), -100% means open up (bottom of screen), -50% means open from middle
-        walletOffset: `calc(${walletOffset}% + ${pxOffset}px)`,
-
         // won't register as 'dragging' until it has actually moved. otherwise its a click
         dragging: dragging && hasMoved,
 
         dragProps: {
             // browsers that don't support dragging need to handle this manually
             draggable: false,
+            // mouse down on the orb, however other listeners (e.g. mouse move) will be on the
+            // full document as native drag events are not supported
             onMouseDown: (e: MouseEvent) => {
+                if (e.button !== 0) return // only left click
                 setHasMoved(false)
                 e.preventDefault()
                 e.stopPropagation()
                 setDragging(true)
 
-                const rec = getParentBoundingRec(e)
-                if (rec) {
-                    setBoundingRec(rec)
-                }
+                const rec = getBoundingRectFromRef(containerRef.current)
+                if (rec) setBoundingRect(rec)
                 setDragStartOffset(e.clientY - handleOffset)
             },
         },
     }
 }
 
-export function useWalletDragger() {
+export function useWalletDragger({ containerRef }: { containerRef: RefObject<HTMLElement | null> }) {
     const isDesktop = useBreakpoint("md")
-    const nativeDragEnabled = isChrome
+    const shared = useWalletDragSharedState(containerRef)
+    const nativeDrag = useNativeDrag(shared)
+    const customDrag = useCustomDrag(shared)
 
-    const nativeDrag = useNativeDrag({ enabled: nativeDragEnabled })
-    const customDrag = useCustomDrag({ enabled: !nativeDragEnabled })
-
-    const dragger = nativeDragEnabled ? nativeDrag : customDrag
+    const dragger = shared.enableNativeDrag ? nativeDrag : customDrag
 
     return {
-        ...dragger,
-        walletOffset: isDesktop ? dragger.walletOffset : 0,
-        handleOffset: isDesktop ? dragger.handleOffset : 0,
+        dragging: dragger.dragging,
+        dragProps: dragger.dragProps,
+        // on mobile, set offset to zero (top of screen, un-draggable)
+        walletOffset: isDesktop ? shared.walletOffset : 0,
+        handleOffset: isDesktop ? shared.handleOffset : 0,
     }
 }

--- a/packages/core/lib/wallet/utils.ts
+++ b/packages/core/lib/wallet/utils.ts
@@ -25,9 +25,17 @@ export function makeBlankImage() {
 }
 
 /**
- * Feature Detection would be much better, however not possible in this case. The primary use here
+ * Determines if the browser supports native drag and drop functionality.
+ * Does not take into account browser quirks such as Firefox incorrectly reporting drop coordinates.
+ */
+export const browserFeatures = {
+    dragAndDrop: typeof document !== "undefined" && "draggable" in document.createElement("div"),
+}
+
+/**
+ * Feature Detection alone would be much better, however not possible in this case. The primary use here
  * is for the drag-and-drop API, which is baseline/'fully supported' on all modern browsers, however
  * the implementation for many (such as Firefox and Safari) is broken in reality.
  */
-export const isFirefox = navigator.userAgent.includes("Firefox")
-export const isChrome = navigator.userAgent.includes("Chrome")
+export const isFirefox = typeof navigator !== "undefined" && navigator.userAgent.includes("Firefox")
+export const isChrome = typeof navigator !== "undefined" && navigator.userAgent.includes("Chrome")

--- a/support/common/lib/utils/throttle.ts
+++ b/support/common/lib/utils/throttle.ts
@@ -3,11 +3,11 @@
  * Executes on the leading edge of the timeout (immediately), and drops subsequent calls
  * until the timeout has ended.
  *
- * default delay is 8ms, which roughly corresponds to 120 FPS
+ * default delay is 16ms, which roughly corresponds to 60 FPS
  *
  * For more info: {@link https://css-tricks.com/debouncing-throttling-explained-examples/}
  */
-export function throttle<T, K>(fn: (a: T) => K, delay = 8) {
+export function throttle<T, K>(fn: (a: T) => K, delay = 16) {
     let throttle: ReturnType<typeof setTimeout> | undefined
     return (args: T) => {
         if (throttle) return


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

Improved the wallet dragging functionality with better cross-browser support and more robust drag handling. This PR:

- Adds a container reference to the wallet component to properly measure its dimensions
- Refactors the drag handling logic to better support different browsers
- Improves feature detection for drag-and-drop capabilities
- Handles edge cases like browser blur events and context menus during dragging
- Makes the code more resilient to SSR environments by checking for window/document availability
- Adds comprehensive documentation to explain the drag behavior and implementation details
- Adjusts the throttle default from 8ms to 16ms (120fps to 60fps) for better performance

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

Chrome, Firefox, and Safari on desktop with the demo app

Tested dragging the wallet handle up and down, resizing the window, and handling edge cases like clicking away during drag

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>