### PR TITLE
Fix iframe connection modal layout and scrolling behavior

### DIFF
--- a/apps/iframe/src/components/interface/connection/ConnectModal.tsx
+++ b/apps/iframe/src/components/interface/connection/ConnectModal.tsx
@@ -24,7 +24,8 @@ import {
 export function ConnectModal() {
     return (
         <main className="h-dvh w-screen rounded-3xl overflow-hidden flex flex-col items-center justify-start">
-            <div className="max-w-xs grid grid-rows-[auto_1fr] gap-6 px-2 p-4 w-full">
+            {/* max-h-screen here refers to the embedded iframe screen, not the window screen */}
+            <div className="max-w-xs grid grid-rows-[auto_1fr] gap-6 px-2 p-4 w-full max-h-screen grow">
                 <div className="flex items-center justify-center mt-12">
                     <div className="flex flex-col items-center gap-2">
                         <img
@@ -35,7 +36,7 @@ export function ConnectModal() {
                         <p className="text-xl font-bold">HappyChain</p>
                     </div>
                 </div>
-                <div className="grid min-h-0 max-h-[335px] h-full gap-4">
+                <div className="grid min-h-0 h-full gap-4">
                     <ConnectContent />
                 </div>
             </div>
@@ -149,10 +150,12 @@ const ConnectContent = () => {
     }
     return (
         <>
-            <div className="overflow-y-auto scrollbar-thin">
+            <div className="overflow-y-auto scrollbar-thin grow">
                 <ProviderList onSelect={mutationLogin.mutate} />
             </div>
-            <CloseButton />
+            <div className="grid items-end justify-stretch">
+                <CloseButton />
+            </div>
         </>
     )
 }


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

Fixed layout issues in the ConnectModal component to improve scrolling behavior and responsiveness in the iframe. The changes include:

- Added a `max-h-screen` class with a comment explaining it refers to the embedded iframe screen
- Added `grow` class to ensure proper vertical expansion
- Removed fixed height constraint (`max-h-[335px]`) to allow for more flexible content sizing
- Improved the positioning of the CloseButton by wrapping it in a grid container
- Enhanced scrolling behavior for the provider list

These changes ensure the connection modal displays correctly across different screen sizes and properly handles overflow content.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>