### PR TITLE
update badge message and state when user closes wallet

### DIFF
--- a/apps/iframe/src/components/interface/GlobalHeader.tsx
+++ b/apps/iframe/src/components/interface/GlobalHeader.tsx
@@ -1,13 +1,8 @@
-import { Msgs } from "@happy.tech/wallet-common"
 import { ArrowLeftIcon, ArrowsInSimpleIcon } from "@phosphor-icons/react"
 import { useRouter } from "@tanstack/react-router"
-import { appMessageBus } from "#src/services/eventBus"
 import { navigationStateManager } from "#src/utils/NavStateManager"
+import { signalClosed } from "#src/utils/walletState.ts"
 import { TriggerSecondaryActionsMenu } from "./menu-secondary-actions/SecondaryActionsMenu"
-
-function signalClosed() {
-    void appMessageBus.emit(Msgs.WalletVisibility, { isOpen: false })
-}
 
 export const GlobalHeader = () => {
     const router = useRouter()
@@ -41,7 +36,7 @@ export const GlobalHeader = () => {
                     type="button"
                     aria-label="Click to hide wallet"
                     className="dark:opacity-60"
-                    onClick={signalClosed}
+                    onClick={() => signalClosed(undefined)}
                 >
                     <ArrowsInSimpleIcon weight="bold" />
                 </button>

--- a/apps/iframe/src/components/interface/connection/ConnectModal.tsx
+++ b/apps/iframe/src/components/interface/connection/ConnectModal.tsx
@@ -154,7 +154,7 @@ const ConnectContent = () => {
                 <ProviderList onSelect={mutationLogin.mutate} />
             </div>
             <div className="grid items-end justify-stretch">
-                <CloseButton />
+                <CloseButton req={clientConnectionRequest ?? undefined} />
             </div>
         </>
     )

--- a/apps/iframe/src/components/interface/connection/errors.tsx
+++ b/apps/iframe/src/components/interface/connection/errors.tsx
@@ -1,5 +1,5 @@
 import { CreateAccount } from "@happy.tech/boop-sdk"
-import type { ConnectionProvider } from "@happy.tech/wallet-common"
+import type { ConnectionProvider, Msgs, MsgsFromApp } from "@happy.tech/wallet-common"
 import { EIP1193UserRejectedRequestError } from "@happy.tech/wallet-common"
 import { cx } from "class-variance-authority"
 import type { PropsWithChildren } from "react"
@@ -115,9 +115,14 @@ export function PendingProvider({ provider, onCancel }: { provider: ConnectionPr
     )
 }
 
-export function CloseButton() {
+export function CloseButton({ req }: { req?: MsgsFromApp[Msgs.ConnectRequest] | null }) {
     return (
-        <Button intent="ghost" type="button" className="h-fit justify-center" onClick={signalClosed}>
+        <Button
+            intent="ghost"
+            type="button"
+            className="h-fit justify-center"
+            onClick={() => signalClosed(req ?? undefined)}
+        >
             Close
         </Button>
     )

--- a/apps/iframe/src/routes/embed.lazy.tsx
+++ b/apps/iframe/src/routes/embed.lazy.tsx
@@ -49,7 +49,7 @@ function Embed() {
                     signalOpen()
                     break
                 case WalletDisplayAction.Closed:
-                    signalClosed()
+                    signalClosed(undefined)
                     setSecondaryMenuVisibility(false)
                     setDialogLogoutVisibility(false)
                     break

--- a/apps/iframe/src/utils/walletState.ts
+++ b/apps/iframe/src/utils/walletState.ts
@@ -1,4 +1,4 @@
-import { AuthState, Msgs } from "@happy.tech/wallet-common"
+import { AuthState, Msgs, type MsgsFromApp } from "@happy.tech/wallet-common"
 import { appMessageBus } from "#src/services/eventBus"
 import { getAuthState } from "#src/state/authState"
 import { setWalletOpenSignal } from "#src/state/interfaceState"
@@ -14,9 +14,19 @@ export function signalOpen() {
     patchTimeoutOn()
     void appMessageBus.emit(Msgs.WalletVisibility, { isOpen: true })
 }
-export function signalClosed() {
+
+export function signalClosed(request?: MsgsFromApp[Msgs.ConnectRequest]) {
     patchTimeoutOff()
     void appMessageBus.emit(Msgs.WalletVisibility, { isOpen: false })
+
+    // if a connection request is provided, also emits a ConnectResponse event with a null response,
+    // indicating that the connection attempt was cancelled or not completed.
+    if (request) {
+        void appMessageBus.emit(Msgs.ConnectResponse, {
+            request: request,
+            response: null,
+        })
+    }
 }
 
 /**

--- a/packages/core/lib/badge/useConnection.ts
+++ b/packages/core/lib/badge/useConnection.ts
@@ -1,27 +1,9 @@
 import { EIP1193ErrorCodes } from "@happy.tech/wallet-common"
-import { useCallback, useEffect, useState } from "preact/hooks"
+import { useCallback, useState } from "preact/hooks"
 import { connect as hcConnect, disconnect as hcDisconnect, openWallet } from "../functions"
-import { internalProvider } from "../happyProvider"
 
 export function useConnection() {
     const [connecting, setConnecting] = useState(false)
-
-    /**
-     * Resets the connecting state when wallet is closed.
-     *
-     * This ensures the badge doesn't get stuck showing "Connecting"
-     * if the wallet is closed during a connection attempt. Affects:
-     * - Button disabled state
-     * - Label text ("Connect"/"Connecting"/user info)
-     * - Click handler behavior
-     */
-    useEffect(() => {
-        return internalProvider.onWalletVisibilityUpdate(({ isOpen }) => {
-            if (!isOpen) {
-                setConnecting(false)
-            }
-        })
-    }, [])
 
     const connect = useCallback(async () => {
         try {


### PR DESCRIPTION
### Linked Issues

- closes https://linear.app/happychain/issue/HAPPY-620/connect-button-should-snap-off-connecting-if-we-close-the-wallet

### Description

This PR improves the connection handling in the badge component by:

~1. Adding a `closeWallet()` function to complement the existing `openWallet()` function~ (not needed)
2. Enhancing the `useConnection` hook with:
   - A new `close` method to properly close the wallet
   - Automatic reset of the connecting state when the wallet is closed
   - Better error handling using standardized EIP1193 error codes
3. Removing an extra space in the error display component's className

These changes ensure the badge doesn't get stuck in a "Connecting" state if the user closes the wallet during a connection attempt, improving the overall user experience.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>