### PR TITLE
Add min-height to counter display container

### DIFF
--- a/demos/react/src/demo-components/ContractInteractionDemo.tsx
+++ b/demos/react/src/demo-components/ContractInteractionDemo.tsx
@@ -46,7 +46,7 @@ export const ContractInteractionDemo = () => {
             </div>
 
             {/* Counter Display */}
-            <div className="col-span-2 text-center mt-2">
+            <div className="col-span-2 text-center mt-2 min-h-16">
                 <pre className="text-sm font-semibold">Current counter value</pre>
                 {count !== undefined ? (
                     <div className="text-4xl font-bold">{count.toString()}</div>


### PR DESCRIPTION
### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

Added a minimum height to the counter display container in the Contract Interaction Demo component to prevent layout shifts when the counter value is loading or not yet available.

The change adds `min-h-16` class to the counter display div, ensuring that the container maintains a consistent height regardless of whether the counter value is displayed or not.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>