### PR TITLE
fix: remove replica node url from submitter deploys

### DIFF
--- a/.github/workflows/deploy-staging-submitter.yml
+++ b/.github/workflows/deploy-staging-submitter.yml
@@ -60,7 +60,7 @@ jobs:
             DATABASE_URL=/home/staging_submitter/db.sqlite
             CHAIN_ID=216
             NODE_ENV=staging
-            RPC_URLS=ws://localhost:8546,http://localhost:8545,wss://rpc.testnet.happy.tech/ws,https://rpc.testnet.happy.tech/http
+            RPC_URLS=wss://rpc.testnet.happy.tech/ws,https://rpc.testnet.happy.tech/http
             USE_STAGING_CONTRACTS=true
             TRACES_ENDPOINT=http://localhost:4318/v1/traces
             PROMETHEUS_PORT=9091

--- a/.github/workflows/deploy-submitter.yml
+++ b/.github/workflows/deploy-submitter.yml
@@ -60,7 +60,7 @@ jobs:
             DATABASE_URL=/home/submitter/db.sqlite
             CHAIN_ID=216
             NODE_ENV=production
-            RPC_URLS=ws://localhost:8546,http://localhost:8545,wss://rpc.testnet.happy.tech/ws,https://rpc.testnet.happy.tech/http
+            RPC_URLS=wss://rpc.testnet.happy.tech/ws,https://rpc.testnet.happy.tech/http
             TRACES_ENDPOINT=http://localhost:4318/v1/traces
             PROMETHEUS_PORT=9092
             LOG_COLORS=false

--- a/apps/submitter/lib/services/BlockService.ts
+++ b/apps/submitter/lib/services/BlockService.ts
@@ -520,7 +520,7 @@ export class BlockService {
         // Use a Mutex to avoid backfilling the same range many times.
         return this.#backfillMutex.locked(async () => {
             // It's possible all or part of the range was backfilled while we were waiting.
-            if (this.#current?.number ?? 0n > from) from = this.#current!.number
+            if ((this.#current?.number ?? 0n) > from) from = this.#current!.number
             if (from >= to) return true
 
             blockLogger.info(`Backfilling blocks in [${from}, ${to}] (inclusive).`)


### PR DESCRIPTION
The replica is so far behind tip/head of chain, it causes all sorts of issues on submitter re-boot. This fixes it for now by only using the caldera node. 

### Linked Issues

- closes #XXX
- closes HAPPY-XXX

### Description

< DESCRIPTION GOES HERE >

- Include all relevant context (but no need to repeat the issue's content).
- Draw attention to new, noteworthy & unintuitive elements.

<details open>
<summary>Toggle Checklist</summary>

## Checklist

### Basics

- [ ] B1. I have applied the proper label & proper branch name (e.g. `norswap/build-system-caching`).
- [ ] B2. This PR is not so big that it should be split & addresses only one concern.
- [ ] B3. The PR targets the lowest branch it can (ideally master).

Reminder: [PR review guidelines][guidelines]

[guidelines]: https://www.notion.so/happychain/PR-Process-12404b72a585807bb8bce20783acf631

### Correctness

- [ ] C1. Builds and passes tests.
- [ ] C2. The code is properly parameterized & compatible with different environments (e.g. local,
      testnet, mainnet, standalone wallet, ...).
- [ ] C3. I have manually tested my changes & connected features.

< INDICATE BROWSER, DEMO APP & OTHER ENV DETAILS USED FOR TESTING HERE >

< INDICATE TESTED SCENARIOS (USER INTERFACE INTERACTION, CODE FLOWS) HERE >

- [ ] C4. I have performed a thorough self-review of my code after submitting the PR,
      and have updated the code & comments accordingly.

### Architecture & Documentation

- [ ] D1. I made it easy to reason locally about the code, by (1) using proper abstraction boundaries,
      (2) commenting these boundaries correctly, (3) adding inline comments for context when needed.
- [ ] D2. All public-facing APIs are documented in the docs.  
          Public APIS and meaningful (non-local) internal APIs are properly documented in code comments.
- [ ] D3. If appropriate, the general architecture of the code is documented in a code comment or
          in a Markdown document.
- [ ] D4. An appropriate Changeset has been generated (and committed) with `make changeset` for
          breaking and meaningful changes in packages (not required for cleanups & refactors).

</details>
