### PR TITLE
Submitter: fix backfill clamping + misc RPC selection fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -691,20 +691,33 @@ select-docs-prod:
 	make select-docs url=https://docs.happy.tech posthog=true
 .PHONY: select-docs-prod
 
+# Use the local setup (chain & all services to run locally).
 select-all-local: select-chain-local select-submitter-local select-iframe-local select-auth-local select-docs-local
 .PHONY: select-all-local
 
+# Use the staging setup — this is useful as a base for other rules & for scripts.
 select-all-staging: select-chain-staging select-submitter-staging select-iframe-staging select-auth-staging select-docs-staging
 .PHONY: select-all-staging
 
+# Use the prod setup — this is useful for bundling/publishing packages, and as a base for other rules & for scripts.
 select-all-prod: select-chain-prod select-submitter-prod select-iframe-prod select-auth-prod select-docs-prod
 .PHONY: select-all-prod
 
+# Use the staging setup, but run the iframe locally.
 select-iframe-dev-staging: select-all-staging select-iframe-local
 .PHONY: select-iframe-dev-staging
 
+# Use the prod setup, but run the iframe locally.
 select-iframe-dev-prod: select-all-prod select-iframe-local
 .PHONY: select-iframe-dev-prod
+
+# Use the staging setup, but run the iframe and the submitter locally.
+select-submitter-dev-staging: select-iframe-dev-staging select-submitter-staging
+.PHONY: select-submitter-dev-staging
+
+# Use the prod setup, but run the iframe and submitter locally.
+select-submitter-dev-prod: select-iframe-dev-prod select-submitter-prod
+.PHONY: select-submitter-dev-prod
 
 setup-local-chain: select-chain-local
 	@cd contracts && make anvil-background

--- a/apps/submitter/build.config.ts
+++ b/apps/submitter/build.config.ts
@@ -5,6 +5,7 @@ export default defineConfig([
         exports: [".", "./migrate"],
         bunConfig: {
             target: "bun",
+            minify: false,
         },
     },
     {

--- a/apps/submitter/lib/services/BlockService.ts
+++ b/apps/submitter/lib/services/BlockService.ts
@@ -549,7 +549,7 @@ export class BlockService {
         // Use a Mutex to avoid backfilling the same range many times.
         return this.#backfillMutex.locked(async () => {
             // It's possible all or part of the range was backfilled while we were waiting.
-            if (this.#current?.number ?? 0n > from) from = this.#current!.number
+            if ((this.#current?.number ?? 0n) > from) from = this.#current!.number
             if (from >= to) return true
 
             blockLogger.info(`Backfilling blocks in [${from}, ${to}] (inclusive).`)

--- a/apps/submitter/lib/services/BlockService.ts
+++ b/apps/submitter/lib/services/BlockService.ts
@@ -221,11 +221,8 @@ export class BlockService {
                         localMax = r.value
                     }
                 }
-                // TODO: I don't think we need to check .number, and we should only reset if the history does have
-                //       the block!
-                //       This probably does not explain the issues with one correct RPC and a stalled/lagging RPC:
-                //       the current RPC should win the race... unless it flakes on getBlock (which would be unlucky).
-                if (localMax.number && this.#blockHistory.get(localMax.number) !== localMax.hash) {
+                const oldBlockHash = this.#blockHistory.get(localMax.number)
+                if (oldBlockHash && oldBlockHash !== localMax.hash) {
                     // A re-org might have occured — reset block number and check for forward movement from there.
                     current = localMax
                 }

--- a/apps/submitter/lib/services/BlockService.ts
+++ b/apps/submitter/lib/services/BlockService.ts
@@ -260,11 +260,7 @@ export class BlockService {
         // We got a new block in the whole affair, handle it.
         // This is always ok: this is either a more recent block or a re-org occured.
         const newBlock = (rpcResults[index] as PromiseFulfilledResult<Block>).value
-        // TODO: The condition here contradict the comment above: if a re-org occured and the block number went down,
-        //        we do not call handle. Need to check that #handleNewBlock can handle this correctly + that this
-        //        doesn't lead to a duplicate handleNewBlock call (the progress check above should in theory ensure that
-        //        it doesn't, but let's also verify that we can't handle #handleNewBlock form a stray handler).
-        if (!this.#current || this.#current.number < newBlock.number) this.#handleNewBlock(newBlock)
+        this.#handleNewBlock(newBlock)
     }
 
     // TODO Verify and update this comment to account for the fact we don't rely on the Viem nonce manager anymore,

--- a/apps/submitter/lib/services/BlockService.ts
+++ b/apps/submitter/lib/services/BlockService.ts
@@ -201,9 +201,7 @@ export class BlockService {
         // === Check to see if block production has halted ===
 
         const halted = !rpcResults.some((it) => isSuccess(it) && it.value.number > (this.#current?.number ?? 0n))
-        // TODO Is the this.#client check actually necessary?
-        // Check `this.#client` to avoid waiting & logging an error on initial RPC selection.
-        if (this.#client && halted) {
+        if (halted) {
             // This might trigger at the start of testing and is benign, it just means the RPC isn't spun up yet.
             const message = "Block production has halted, waiting for it to resume."
             blockLogger.error(message)

--- a/apps/submitter/lib/services/BlockService.ts
+++ b/apps/submitter/lib/services/BlockService.ts
@@ -564,9 +564,9 @@ export class BlockService {
                     // Filled in meanwhile, move forward.
                     if (this.#current?.number ?? 0n > blockNumber) continue
                     const block = await promises[Number(blockNumber - from)]
-                    if (!block) throw "Block was undefined" // this shouldn't happen
+                    if (!block) throw Error("Block was undefined") // this shouldn't happen
                     // Disallow recursive backfills. Should never happen, but theoretically possible with reorgs.
-                    if (!(await this.#handleNewBlock(block, false))) throw "Block was skipped."
+                    if (!(await this.#handleNewBlock(block, false))) throw Error("Block was skipped.")
                 } catch (e) {
                     // If the block was filled meanwhile, we can move forward.
                     if (this.#current?.number ?? 0n > blockNumber) continue

--- a/apps/submitter/lib/services/BlockService.ts
+++ b/apps/submitter/lib/services/BlockService.ts
@@ -263,14 +263,11 @@ export class BlockService {
         this.#handleNewBlock(newBlock)
     }
 
-    // TODO Verify and update this comment to account for the fact we don't rely on the Viem nonce manager anymore,
-    //      but on our own.
-
-    // Note that in the case of re-orgs, we will be missing blocks compared to the "most re-orged"
-    // block that we saw. We should handle that but don't sweat too much about it right now. We
-    // haven't really audited the code for re-orgs. In theory, the Viem nonce manager should handle
-    // EVM tx nonces. Boop nonces get a resync via `InvalidNonce`, and the nonce cache expires fast
-    // anyway. We might suffer from stuck transactions in the future (meant for pre-re-org chain).
+    // Note that in the case of re-orgs, we might be missing blocks compared to the "most re-orged" block that we saw.
+    // We should handle that but don't sweat too much about it right now. We haven't really audited the code for
+    // re-orgs. Our nonce manager should handle EVM tx nonces. Boop nonces get a resync via `InvalidNonce`, and the
+    // nonce cache expires fast anyway. We might suffer from stuck transactions in the future (meant for pre-re-org
+    // chain).
     //
     // The most immediate to-do item is to call out the resync system to cancel submit and
     // createAccount transactions, which we need for robustness.


### PR DESCRIPTION
Currently, our local node replica is fubared, it's lagging a few days behind the sequencer and making progress, albeit at a fraction of the normal pace.

This uncovered a bunch of interesting issues, and this is a first PR to address them.

- First, it showed that the backfill logic, which normally gets clamped to a max number of blocks (15 by default) wasn't operating because of a dumb operator precedence issue.
- Second, we didn't necessarily select an RPC that had made forward block progress during RPC selection.

This does not solve all the issues. We just haven't really considered this scenario where a RPC is live but largely trailing.

The main issue is not in the block subscription anymore, but in all the others RPC calls, which simply attempt to use the RPCs in the defined order, falling back in list order. The fix (for later) will be to implement a Viem client proxy that uses the RPC selected by the block service as its default block.